### PR TITLE
set timeout-minutes to 8 hours as jobs are not completing

### DIFF
--- a/.github/workflows/create-addon.yml
+++ b/.github/workflows/create-addon.yml
@@ -91,6 +91,8 @@ jobs:
   create_addon:
     runs-on: [self-hosted, nightly]
 
+    timeout-minutes: 480
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Running 3 concurrent addon builds on the runner with the self compiled
llvm and rust exceeds the default 360 minutes.

jobs.<job_id>.timeout-minutes
- The maximum number of minutes to let a job run before GitHub
  automatically cancels it. Default: 360

Reference:
- https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes