### PR TITLE
force removal of the files

### DIFF
--- a/.github/workflows/clean-img.yml
+++ b/.github/workflows/clean-img.yml
@@ -42,7 +42,7 @@ jobs:
                         awk 'NR>2' | \
                           while read file; do
                             echo "Removing old image file ${file}" 
-                            ssh -p ${{ secrets.NIGHTLY_HOST_PORT }} ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} rm ${file} ${file}.sha256
+                            ssh -p ${{ secrets.NIGHTLY_HOST_PORT }} ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} rm -f ${file} ${file}.sha256
                           done
                   done
           ssh -p ${{ secrets.NIGHTLY_HOST_PORT }} ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} \


### PR DESCRIPTION
the .sha256 file if not existing, will cause the rm to fail, so use -f
to delete the files.