### PR TITLE
fix device subdirectory builds

### DIFF
--- a/.github/workflows/clean-img.yml
+++ b/.github/workflows/clean-img.yml
@@ -15,6 +15,7 @@ on:
         options:
           - no_run_clean
           - run_clean
+          - force_remove_le11
 jobs:
   clean_img:
     runs-on: [self-hosted, scripts]
@@ -25,6 +26,13 @@ jobs:
           echo "github.event.inputs.run_clean = ${{ github.event.inputs.run_clean }}"
           echo "github.event.workflow_run.event = ${{ github.event.workflow_run.event }}"
 
+      - name: Force remove image files in the test.libreelec.tv 11.0 directory
+        if: |
+          (github.event.inputs.run_clean == 'force_remove_le11')
+        run: |
+          ssh -p ${{ secrets.NIGHTLY_HOST_PORT }} ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} \
+            "find ${{ secrets.NIGHTLY_UPLOAD_PATH }}/11.0 -type f rm {} \;"
+
       - name: Remove old image files in the test.libreelec.tv directory
         if: |
           (github.event.inputs.run_clean == 'run_clean') || 
@@ -32,7 +40,7 @@ jobs:
           (github.event.workflow_run.event == 'workflow_dispatch')
         run: |
           ssh -p ${{ secrets.NIGHTLY_HOST_PORT }} ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} \
-            "ls ${{ secrets.NIGHTLY_UPLOAD_PATH }}/*/*/LibreELEC-*.{img.gz,tar,ova}" < /dev/null | \
+            "ls ${{ secrets.NIGHTLY_UPLOAD_PATH }}/*/*/*/LibreELEC-*.{img.gz,tar,ova}" < /dev/null | \
             sed 's#nightly-[0-9]*-[a-z0-9]*#nightly-\*#' | \
               sort | \
                 uniq | \

--- a/.github/workflows/make-image.yml
+++ b/.github/workflows/make-image.yml
@@ -252,7 +252,7 @@ jobs:
             for f in target/*.img.gz; do
               uboot_device="$(echo "${f##*/}" | sed -rn 's/(LibreELEC-.*.(arm|aarch64|x86_64)-[0-9.]+-nightly-[0-9.]{8}-[[0-9a-f]{7})(-)(.*)(.img.gz*)/\4/p')"
               ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} "mkdir -p ${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}"
-              scp -P ${{ secrets.NIGHTLY_HOST_PORT }} target/*.{img.gz,img.gz.sha256} \
+              scp -P ${{ secrets.NIGHTLY_HOST_PORT }} ${f} ${f}.sha256 \
                 ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}/
             done
           fi


### PR DESCRIPTION
- clean-img: unable a full clean of the 11.0 directory and clean from subdirs
  - clean full img directory
  - clean from subdirectories 
- make-image: only copy the matching u-boot image
  - minor fix to only copy the single file in the u-boot loop