### PR TITLE
make-image: add missing quotes in upload test

### DIFF
--- a/.github/workflows/make-image.yml
+++ b/.github/workflows/make-image.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           ls -lah target/
-          if [ ${{env.PROJECT }} == "Generic" || ${{env.PROJECT }} == "RPi" ]; then
+          if [ "${{env.PROJECT }}" == "Generic" || "${{env.PROJECT }}" == "RPi" ]; then
             ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} "mkdir -p ${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${{ env.DEVICE }}"
             scp -P ${{ secrets.NIGHTLY_HOST_PORT }} target/*.{img.gz,img.gz.sha256} \
               ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${{ env.DEVICE }}/


### PR DESCRIPTION
The comparison is failing as RPi does not equal “RPi” (same for Generic.) 
Add missing quotes.