### PR TITLE
make-image: fix test using bash double brackets

### DIFF
--- a/.github/workflows/make-image.yml
+++ b/.github/workflows/make-image.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           ls -lah target/
-          if [ "${{env.PROJECT }}" == "Generic" || "${{env.PROJECT }}" == "RPi" ]; then
+          if [[ "${{env.PROJECT }}" == "Generic" || "${{env.PROJECT }}" == "RPi" ]]; then
             ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} "mkdir -p ${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${{ env.DEVICE }}"
             scp -P ${{ secrets.NIGHTLY_HOST_PORT }} target/*.{img.gz,img.gz.sha256} \
               ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${{ env.DEVICE }}/


### PR DESCRIPTION
ref:
- http://ftp.tudelft.nl/LDP/LDP/abs/html/abs-guide.html#DBLBRACKETS

    The [[ ]] construct is the more versatile Bash version of [ ]. This is
    the extended test command, adopted from ksh88.

    Using the [[ ... ]] test construct, rather than [ ... ] can prevent many
    logic errors in scripts. For example, the &&, ||, <, and > operators
    work within a [[ ]] test, despite giving an error within a [ ]
    construct.