### PR TITLE
scripts: update changelog at test.le.tv

### DIFF
--- a/.github/workflows/tools-update-changelog.yml
+++ b/.github/workflows/tools-update-changelog.yml
@@ -5,7 +5,7 @@ on:
     - cron: "*/30 * * * *"
 
 jobs:
-  create_addon:
+  update_changelog:
     runs-on: [self-hosted, scripts]
 
     steps:
@@ -18,6 +18,13 @@ jobs:
       - name: Update changelog at test.libreelec.tv
         run: |
           echo "Updating changelog at test.libreelec.tv"
+          ls -lah
+          echo "---------------"
+          pwd
           cd "actions/"
+          ls -lah
+          echo "---------------"
+          tail ./scripts/update_changelog.sh
+          echo "---------------"
           ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
             "bash -s" < ./scripts/update_changelog.sh

--- a/.github/workflows/tools-update-changelog.yml
+++ b/.github/workflows/tools-update-changelog.yml
@@ -1,0 +1,22 @@
+name: tools-update-changelog
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  create_addon:
+    runs-on: [self-hosted, scripts]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          repository: "LibreELEC/actions"
+          path: "actions"
+
+      - name: Update changelog at test.libreelec.tv
+        run: |
+          echo "Updating changelog at test.libreelec.tv"
+          cd "actions/"
+          ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
+            "bash -s" < ./scripts/update_changelog.sh

--- a/.github/workflows/tools-update-changelog.yml
+++ b/.github/workflows/tools-update-changelog.yml
@@ -1,5 +1,6 @@
 name: tools-update-changelog
 on:
+  workflow_dispatch:
   schedule:
     - cron: "*/30 * * * *"
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# abort at error
+set -e
+
+# create changelog
+generate_changelog() {
+  # html header
+  cat <<EOF
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="https://test.libreelec.tv/css/listing.css"/>
+</head>
+<body>
+<h2> Changelog</h2>
+<table class="changelogTable" style="width: 100%;">
+<tbody>
+EOF
+
+  # get commits from GH API
+  gh_output="$(curl -sH "Accept: application/vnd.github.v3+json" https://api.github.com/repos/LibreELEC/LibreELEC.tv/commits?per_page=60 | jq '.[] | "\(.commit.author.date | .[0:10]) \(.sha | .[0:7]) \(.commit.message)"' | grep "Merge pull request")"
+
+  while IFS= read -r line; do
+    # PR link
+    var_pr="$(grep -oE '#[0-9]+' <<<"$line")"
+
+    # PR message
+    var_message="$(grep -oP '(?<=\\n\\n)(.*)(?=\")' <<<"$line")"
+
+    # PR date at merge
+    var_date="$(grep -oP '(?<=^")[0-9-]{10}' <<<"$line")"
+
+    # git shorthash
+    var_hash="$(grep -oP '(?<=^"[0-9-]{10} )[0-9a-f]{7}' <<<"$line")"
+
+    # output line
+    echo "<tr><td>$var_date ($var_hash):</td><td><a href=\"https://github.com/LibreELEC/LibreELEC.tv/pull/${var_pr//#/}\" target="_blank" rel="noopener noreferrer">${var_pr}</a></td><td>${var_message}</td></tr>"
+  done <<<"$gh_output"
+
+  # html footer
+  cat <<EOF
+</tbody>
+</table>
+</body>
+</html>
+EOF
+}
+
+# generate and output to file
+generate_changelog >/var/www/test/css/changelog.html


### PR DESCRIPTION
- updates the changelog at the nightly site ([demo](https://test3.libreelec.tv/))

it is a bit overkill, I know but this way we can keep all logic at GHA instead hidden at some server

- completely untested, just works after switch of test3 -> test

Test fails because the needed actionlint option isn't handled by reviewdog ([bug](https://github.com/reviewdog/action-actionlint/issues/76))