### PR TITLE
scripts: allow for blank PR Message

### DIFF
--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -2,7 +2,6 @@
 
 # abort at error
 set -e
-set -x
 
 # create changelog
 generate_changelog() {
@@ -27,7 +26,7 @@ EOF
     var_pr="$(grep -oE '#[0-9]+' <<<"$line")"
 
     # PR message
-    var_message="$(grep -oP '(?<=\\n\\n)(.*)(?=\")' <<<"$line")"
+    var_message="$(grep -oP '(?<=\\n\\n)(.*)(?=\")' <<<"$line" || true)"
 
     # PR date at merge
     var_date="$(grep -oP '(?<=^")[0-9-]{10}' <<<"$line")"


### PR DESCRIPTION
The following output from `jq` would cause the script to fail
```
"2022-11-13 ba9b18d Merge pull request #7125 from by-gnome/firmware-updates"
```