### PR TITLE
Revert "Don’t build faulty addons audiodecoder.fluidsynth and visualization.pictureit"

### DIFF
--- a/.github/workflows/nightly-MASTER-addons.yml
+++ b/.github/workflows/nightly-MASTER-addons.yml
@@ -68,7 +68,7 @@ jobs:
       debug: debug
       ephemeral: ephemeral
       upload: upload
-      buildcmd: "scripts/create_addon ${{ github.event.inputs.buildcmd_target || 'all' }} -audiodecoder.fluidsynth"
+      buildcmd: "scripts/create_addon ${{ github.event.inputs.buildcmd_target || 'all' }}"
       gitref: master
       group: ARMv7_arm
       project: ARM
@@ -93,7 +93,7 @@ jobs:
       debug: debug
       ephemeral: ephemeral
       upload: upload
-      buildcmd: "scripts/create_addon ${{ github.event.inputs.buildcmd_target || 'all' }} -audiodecoder.fluidsynth"
+      buildcmd: "scripts/create_addon ${{ github.event.inputs.buildcmd_target || 'all' }}"
       gitref: master
       group: ARMv8_arm
       project: ARM
@@ -118,7 +118,7 @@ jobs:
       debug: debug
       ephemeral: ephemeral
       upload: upload
-      buildcmd: "scripts/create_addon ${{ github.event.inputs.buildcmd_target || 'all' }} -chrome -audiodecoder.fluidsynth -visualization.pictureit"
+      buildcmd: "scripts/create_addon ${{ github.event.inputs.buildcmd_target || 'all' }} -chrome"
       gitref: master
       group: Generic_x86_64
       project: Generic


### PR DESCRIPTION
This reverts commit 52b2a0ac467fb996b5e3ce4c4c2c0d8d2fb5148e.

These addons are now building correctly
- https://github.com/LibreELEC/LibreELEC.tv/pull/7232
- https://github.com/LibreELEC/LibreELEC.tv/pull/7238