### PR TITLE
nightly-MASTER-addons.yml: allow Generic-legacy to build targets

### DIFF
--- a/.github/workflows/nightly-MASTER-addons.yml
+++ b/.github/workflows/nightly-MASTER-addons.yml
@@ -137,7 +137,6 @@ jobs:
     if: |
       ( needs.check_date.outputs.should_run != 'false' )
         && ( github.event.inputs.target == 'all' || github.event.inputs.target == 'Generic-legacy.x86_64' || github.event_name == 'schedule' )
-        && ( github.event.inputs.buildcmd_target == 'all' || github.event_name == 'schedule' )
     uses: LibreELEC/actions/.github/workflows/create-addon.yml@main
     with:
       clean_le: no_clean_le


### PR DESCRIPTION
Previously Generic-legacy was only allowed to build chrome, so we disabled the capability for buildcmd_target to be set. Now that Generic-legacy is enabled to build a full add on set - enable functionality.