### PR TITLE
tools-cleanup-images: initial commit

### DIFF
--- a/.github/workflows/tools-cleanup-images.yml
+++ b/.github/workflows/tools-cleanup-images.yml
@@ -1,0 +1,30 @@
+name: tools-cleanup-images
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  update_changelog:
+    runs-on: [self-hosted, scripts]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repository: "LibreELEC/actions"
+          submodules: "true"
+          path: "actions"
+
+      - name: Cleanup nightly images
+        run: |
+          scp -P ${{ secrets.NIGHTLY_HOST_PORT }} actions/scripts/remote/release-scripts/prune-archive.py \
+            ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:/tmp
+
+          # LE10
+          ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
+            "python3 /tmp/prune-archive.py -i /var/www/test/10.0/ -k 100"
+
+          # LE11
+          ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
+            "python3 /tmp/prune-archive.py -i /var/www/test/11.0/ -k 200"


### PR DESCRIPTION
Action to delete images frequently. 
The `prune-archive.py` script keeps one image per week if it is older then for example 100 days (`-k 100`).
