### PR TITLE
create-addon: extend job timeouts from 480 to 720 minutes 

### DIFF
--- a/.github/workflows/create-addon.yml
+++ b/.github/workflows/create-addon.yml
@@ -91,7 +91,7 @@ jobs:
   create_addon:
     runs-on: [self-hosted, nightly]
 
-    timeout-minutes: 480
+    timeout-minutes: 720
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Jobs are being terminated after 480 minutes, extend to 720 minutes.
They are at ~90+% complete at the 480 minute mark.

e.g.
```
[636/638] [DONE] build   system-tools:target
Error: The operation was canceled.
```

- ARMv8.aarch64 / create_addon
  - The job running on runner runner-13 has exceeded the maximum execution time of 480 minutes.