### PR TITLE
create-addon: no longer link cc to gcc-10.0 since jammy

### DIFF
--- a/.github/workflows/create-addon.yml
+++ b/.github/workflows/create-addon.yml
@@ -106,7 +106,7 @@ jobs:
           cd LibreELEC.tv
           sed -i -e "s/RUN adduser/RUN adduser --uid $(id -u)/" tools/docker/focal/Dockerfile
           # workaround until buildsystem does not require local cc
-          sed -i -e "/^USER docker/i RUN ln -s /usr/bin/gcc-10 /usr/bin/cc" tools/docker/focal/Dockerfile
+          #sed -i -e "/^USER docker/i RUN ln -s /usr/bin/gcc-10 /usr/bin/cc" tools/docker/focal/Dockerfile
           sed -i -e 's/^CCACHE_CACHE_SIZE=.*/CCACHE_CACHE_SIZE="${{ inputs.ccachecachesize }}"/' config/options
           echo "LE_ADDON_VERSION=$(grep -oP -m 1 '(?<=ADDON_VERSION=\").*(?=\")' distributions/LibreELEC/version)" >> $GITHUB_ENV
 


### PR DESCRIPTION
fixes LibreELEC-11.0 Add-on builds

```
 > [6/6] RUN ln -s /usr/bin/gcc-10 /usr/bin/cc:
#9 13.52 ln: failed to create symbolic link '/usr/bin/cc': File exists ------
Dockerfile:30
--------------------
  28 |      && rm -rf /var/lib/apt/lists/*
  29 |     
  30 | >>> RUN ln -s /usr/bin/gcc-10 /usr/bin/cc
  31 |     USER docker
  32 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c ln -s /usr/bin/gcc-10 /usr/bin/cc" did not complete successfully: exit code: 1
```