### PR TITLE
migrate set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -73,6 +73,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
 
   # Allwinner
   A64_aarch64:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           cd LibreELEC.tv
-          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "::set-output name=should_run::false"
+          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
 
   # Allwinner
   A64_aarch64:

--- a/.github/workflows/nightly-LE10-addons.yml
+++ b/.github/workflows/nightly-LE10-addons.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           cd LibreELEC.tv
-          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "::set-output name=should_run::false"
+          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
 
   # Addons
   ARMv7_arm-10_0:

--- a/.github/workflows/nightly-LE10-addons.yml
+++ b/.github/workflows/nightly-LE10-addons.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
 
   # Addons
   ARMv7_arm-10_0:

--- a/.github/workflows/nightly-LE10.yml
+++ b/.github/workflows/nightly-LE10.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           cd LibreELEC.tv
-          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "::set-output name=should_run::false"
+          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
 
   # Allwinner
   A64_arm-10_0:

--- a/.github/workflows/nightly-LE10.yml
+++ b/.github/workflows/nightly-LE10.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
 
   # Allwinner
   A64_arm-10_0:

--- a/.github/workflows/nightly-LE11-addons.yml
+++ b/.github/workflows/nightly-LE11-addons.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           cd LibreELEC.tv
-          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "::set-output name=should_run::false"
+          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
 
   # Addons
   ARMv7_arm-11_0:

--- a/.github/workflows/nightly-LE11-addons.yml
+++ b/.github/workflows/nightly-LE11-addons.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
 
   # Addons
   ARMv7_arm-11_0:

--- a/.github/workflows/nightly-LE11.yml
+++ b/.github/workflows/nightly-LE11.yml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           cd LibreELEC.tv
-          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "::set-output name=should_run::false"
+          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
 
   # Allwinner
   A64_arm-11_0:

--- a/.github/workflows/nightly-LE11.yml
+++ b/.github/workflows/nightly-LE11.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
 
   # Allwinner
   A64_arm-11_0:

--- a/.github/workflows/nightly-MASTER-addons.yml
+++ b/.github/workflows/nightly-MASTER-addons.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           cd LibreELEC.tv
           test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
 
   # Addons
   ARMv7_arm:

--- a/.github/workflows/nightly-MASTER-addons.yml
+++ b/.github/workflows/nightly-MASTER-addons.yml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           cd LibreELEC.tv
-          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "::set-output name=should_run::false"
+          test -z "$(git rev-list --after='24 hours' $(git rev-parse HEAD))" && echo "should_run=false" >> $GITHUB_OUTPUT
 
   # Addons
   ARMv7_arm:

--- a/.github/workflows/update-cacert-pem-certificate-bundle.yml
+++ b/.github/workflows/update-cacert-pem-certificate-bundle.yml
@@ -28,15 +28,15 @@ jobs:
         run: |
           sha=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ env.CERTDATA_OWNER }}/${{ env.CERTDATA_REPO }}/commits?path=${{ env.CERTDATA_PATH }}&sha=master&per_page=1" | jq ".[0] | .sha" -r)
-          echo "::set-output name=sha::${sha}"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
 
           authordate=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ env.CERTDATA_OWNER }}/${{ env.CERTDATA_REPO }}/commits?path=${{ env.CERTDATA_PATH }}&sha=master&per_page=1" | \
             jq ".[0] | .commit.author.date" -r | cut -f 1 -d T)
-          echo "::set-output name=authordate::${authordate}"
+          echo "authordate=${authordate}" >> $GITHUB_OUTPUT
 
           download_url="https://github.com/${{ env.CERTDATA_OWNER }}/${{ env.CERTDATA_REPO }}/blob/${sha}/${{ env.CERTDATA_PATH }}?raw=true"
-          echo "::set-output name=download_url::${download_url}"
+          echo "download_url=${download_url}" >> $GITHUB_OUTPUT
 
       - name: Download certdata.txt from https://github.com/mozilla/gecko-dev
         run: |
@@ -59,7 +59,7 @@ jobs:
         id: head_branch
         run: |
           sha=$(git rev-parse refs/heads/master)
-          echo "::set-output name=sha::${sha}"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
- update-cacert-pem-certificate-bundle: migrate set-output to GITHUB_OUTPUT
  - fixes: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- migrate set-output to GITHUB_OUTPUT
  - fixes: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- fix warning due to test -z return 1