### PR TITLE
build-images.yml: fix AMLGX/DragonBoard/RK3328/RK3399 aarch64 builds

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -221,7 +221,7 @@ jobs:
       gitref: ${{ github.event.inputs.gitref_to_build || 'master' }}
       group: AMLGX_aarch64
       project: Amlogic
-      arch: arm
+      arch: aarch64
       device: AMLGX
       targetbuilddir: build.LibreELEC-AMLGX.aarch64-12.0-devel
       buildperiodic: ${{ github.event.inputs.le_periodic_version || 'nightly' }}
@@ -354,7 +354,7 @@ jobs:
       gitref: ${{ github.event.inputs.gitref_to_build || 'master' }}
       group: Dragonboard_aarch64
       project: Qualcomm
-      arch: arm
+      arch: aarch64
       device: Dragonboard
       targetbuilddir: build.LibreELEC-Dragonboard.aarch64-12.0-devel
       buildperiodic: ${{ github.event.inputs.le_periodic_version || 'nightly' }}
@@ -406,7 +406,7 @@ jobs:
       gitref: ${{ github.event.inputs.gitref_to_build || 'master' }}
       group: RK3328_aarch64
       project: Rockchip
-      arch: arm
+      arch: aarch64
       device: RK3328
       targetbuilddir: build.LibreELEC-RK3328.aarch64-12.0-devel
       buildperiodic: ${{ github.event.inputs.le_periodic_version || 'nightly' }}
@@ -431,7 +431,7 @@ jobs:
       gitref: ${{ github.event.inputs.gitref_to_build || 'master' }}
       group: RK3399_aarch64
       project: Rockchip
-      arch: arm
+      arch: aarch64
       device: RK3399
       targetbuilddir: build.LibreELEC-RK3399.aarch64-12.0-devel
       buildperiodic: ${{ github.event.inputs.le_periodic_version || 'nightly' }}
@@ -516,7 +516,7 @@ jobs:
       version: "12.0"
       file_extension: img.gz,tar
     secrets: inherit
-    
+
   # Samsung
   Exynos_arm:
     name: Exynos.arm


### PR DESCRIPTION
Commit 7ad19a1138995d422ced68d928256f55e41d1d40 switched AMLGX to aarch64 .. only it missed changing `arch`so all the folders read aarch64 but the build command issued to the container is still arm, e.g. this build run https://github.com/LibreELEC/actions/actions/runs/7142526981/job/19452013009 shows:

```
  docker run --rm -v /var/media/DATA/github-actions/sources:/sources \
                  -v /var/media/DATA/github-actions/target:/target \
                  -v /var/media/DATA/github-actions/build-root:/build-root \
                  -v `pwd`:/build \
                  -w /build -i \
                  -e PROJECT=Amlogic \
                  -e ARCH=arm \
                  -e DEVICE=AMLGX \
                  -e ONELOG=no -e LOGCOMBINE=fail \
                  -e BUILD_DIR=/build \
                  -e BUILD_PERIODIC=nightly \
                  -e CCACHE_DISABLE=1 \
                  gh-7142526981 make image 
```
And all the AMLGX files for download on the test server are indeed still arm architecture. After reviewing the `build-images.yml` file I can see DragonBoard, RK3328, and RK3399 are similarly configured, so fix them (and an errant tab) too.