### PR TITLE
Update to Node.js 20

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -57,7 +57,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 2

--- a/.github/workflows/create-addon.yml
+++ b/.github/workflows/create-addon.yml
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 720
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitref }}
           fetch-depth: 2

--- a/.github/workflows/make-image.yml
+++ b/.github/workflows/make-image.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: [self-hosted, nightly]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitref }}
           fetch-depth: 2

--- a/.github/workflows/nightly-LE10-addons.yml
+++ b/.github/workflows/nightly-LE10-addons.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: libreelec-10.0
           fetch-depth: 2

--- a/.github/workflows/nightly-LE10.yml
+++ b/.github/workflows/nightly-LE10.yml
@@ -48,7 +48,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: libreelec-10.0
           fetch-depth: 2

--- a/.github/workflows/nightly-LE11-addons.yml
+++ b/.github/workflows/nightly-LE11-addons.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: libreelec-11.0
           fetch-depth: 2

--- a/.github/workflows/nightly-LE11.yml
+++ b/.github/workflows/nightly-LE11.yml
@@ -53,7 +53,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: libreelec-11.0
           fetch-depth: 2

--- a/.github/workflows/nightly-MASTER-addons.yml
+++ b/.github/workflows/nightly-MASTER-addons.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 2

--- a/.github/workflows/tools-check-yaml.yml
+++ b/.github/workflows/tools-check-yaml.yml
@@ -7,7 +7,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1
 
         env:

--- a/.github/workflows/tools-cleanup-images.yml
+++ b/.github/workflows/tools-cleanup-images.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, scripts]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: "${{ github.repository_owner }}/actions"

--- a/.github/workflows/tools-update-addon-repo.yml
+++ b/.github/workflows/tools-update-addon-repo.yml
@@ -12,7 +12,7 @@ jobs:
   update_addon_repo:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
           repository: "${{ github.repository_owner }}/actions"

--- a/.github/workflows/tools-update-changelog.yml
+++ b/.github/workflows/tools-update-changelog.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, scripts]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
           repository: "${{ github.repository_owner }}/actions"

--- a/.github/workflows/update-cacert-pem-certificate-bundle.yml
+++ b/.github/workflows/update-cacert-pem-certificate-bundle.yml
@@ -18,7 +18,7 @@ jobs:
       CERTDATA_REPO: gecko-dev
       CERTDATA_PATH: security/nss/lib/ckfw/builtins/certdata.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.LIBREELECBOT_GITHUB_TOKEN }}
           repository: ${{ github.repository_owner }}/LibreELEC.tv


### PR DESCRIPTION
the following warning is issued in our CI/CD. Update to v4 of checkout. We do not use any of the new/existing features, so not expecting any issues.
```
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: 
``` 
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
- https://github.com/actions/checkout/releases