### PR TITLE
update actions/artifacts to v4

### DIFF
--- a/.github/workflows/create-addon.yml
+++ b/.github/workflows/create-addon.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Upload failed artifacts - ephemeral
         if: inputs.ephemeral == 'ephemeral'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.group }}-failed
           path: LibreELEC.tv/${{ env.TARGETBUILDDIR }}/artifact/
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload failed artifacts - no_ephemeral
         if: inputs.ephemeral == 'no_ephemeral'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.group }}-failed
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/

--- a/.github/workflows/make-image.yml
+++ b/.github/workflows/make-image.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload failed artifacts - ephemeral
         if: inputs.ephemeral == 'ephemeral'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.group }}-failed
           path: LibreELEC.tv/${{ env.TARGETBUILDDIR }}/artifact/
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload failed artifacts - no_ephemeral
         if: inputs.ephemeral == 'no_ephemeral'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.group }}-failed
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/


### PR DESCRIPTION
this update also updates to nodejs 20. the breaking changes do not impact the LE actions as artifacts are already uniquely named.

- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- https://github.com/actions/upload-artifact/releases/tag/v4.0.0