### PR TITLE
limit concurrency, run a single job at a time per branch

### DIFF
--- a/.github/workflows/tools-update-addon-repo.yml
+++ b/.github/workflows/tools-update-addon-repo.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update_addon_repo:
     runs-on: self-hosted


### PR DESCRIPTION
Do not allow workflow to run concurrently, as it acts on the same files.