### PR TITLE
update-cacert-pem-certificate-bundle: change to HEAD not refs/head/master

### DIFF
--- a/.github/workflows/update-cacert-pem-certificate-bundle.yml
+++ b/.github/workflows/update-cacert-pem-certificate-bundle.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Get SHA of the branch that triggered the workflow run
         id: head_branch
         run: |
-          sha=$(git rev-parse refs/heads/master)
+          sha=$(git rev-parse HEAD)
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request


### PR DESCRIPTION
Dont hard code the branch name in the git rev-parse, as the branch name may not be master in the forked repository. Use HEAD instead of refs/heads/master, as we have just checked out ${{ github.repository_owner }}/LibreELEC.tv

We are unable to use ${{ github.ref }} as this resolves to refs/heads/main (as the actions default branch is main - not master.) and the script is run from the ${{ github.repository_owner }}/actions repository.