### PR TITLE
use github.repository to limit running of workflows 

### DIFF
--- a/.github/workflows/tools-cleanup-images.yml
+++ b/.github/workflows/tools-cleanup-images.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   cleanup_images:
+    if: github.repository == 'LibreELEC/actions'
     runs-on: [self-hosted, scripts]
 
     steps:

--- a/.github/workflows/tools-update-changelog.yml
+++ b/.github/workflows/tools-update-changelog.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update_changelog:
+    if: github.repository == 'LibreELEC/actions'
     runs-on: [self-hosted, scripts]
 
     steps:


### PR DESCRIPTION
~~set the following github action variables to allow~~

  ~~SCHED_ENABLE_TOOLS_CLEANUP_IMAGES = scheduled~~
  ~~SCHED_ENABLE_TOOLS_UPDATE_CHANGELOG = scheduled~~
  
Hardcode the following actions only to run in the LibreELEC/actions repo

to allow the following GHA workflows to run

  tools-cleanup-images.yml
  tools-update-changelog.yml

This change allows forks of LibreELEC/actions to "skip" these scheduled workflows as they in general wont work in a fork because they dont have (or need) access to the LE hosting environments.