### PR TITLE
build-LE13: do not schedule or include Dragonboard in all

### DIFF
--- a/.github/workflows/build-LE13.yml
+++ b/.github/workflows/build-LE13.yml
@@ -343,7 +343,7 @@ jobs:
     needs: check_date
     if: |
       ( needs.check_date.outputs.should_run != 'false' )
-        && ( github.event.inputs.target == 'all' || github.event.inputs.target == 'Dragonboard.aarch64' || github.event_name == 'schedule' )
+        && ( github.event.inputs.target == 'Dragonboard.aarch64' )
     uses: ./.github/workflows/yml-uses-make-image-LE13.yml
     with:
       clean_le: no_clean_le


### PR DESCRIPTION
Deprecate Dragonboard builds