### PR TITLE
Update package workflow

### DIFF
--- a/.github/actions/package_version_bump_and_pr_changes/action.yml
+++ b/.github/actions/package_version_bump_and_pr_changes/action.yml
@@ -1,0 +1,95 @@
+inputs:
+  PACKAGE_NAME:
+    description: "package name to update"
+    required: true
+  PACKAGE_VERSION:
+    description: "version to update to"
+    required: false
+  IS_REPO:
+    description: "is this a repository update?"
+    required: false
+  GIT_TOKEN:
+    description: "Token used to push commits"
+    required: true
+
+name: automated-package-update
+description: "Update package version and create a pull request"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+        repository: LibreELEC/LibreELEC.tv
+        ref: master
+        path: LibreELEC-pr/
+    - name: Configure git
+      shell: bash
+      run: |
+        cd LibreELEC-pr/
+        git config user.name "LibreELECBot"
+        git config user.email "LibreELECBot@users.noreply.github.com"
+    - name: Normalize version
+      shell: bash
+      run: |
+        cd LibreELEC-pr/
+        # shorten the version if it is a git sha256 hash
+        # add a full version variable as well
+        PACKAGE_VERSION="${{ inputs.PACKAGE_VERSION }}"
+        PACKAGE_VERSION_FULL="${{ inputs.PACKAGE_VERSION }}"
+        if [[ "${PACKAGE_VERSION}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+          # Git SHA-256 hash to short hash
+          PACKAGE_VERSION="${PACKAGE_VERSION:0:7}"
+        fi
+        # if IS_REPO is true use date as versioning
+        if [[ "${{ inputs.IS_REPO }}" == "yes" ]]; then
+          PACKAGE_VERSION="$(date '+%Y%m%d-%H%M%S')"
+          PACKAGE_VERSION_FULL="${PACKAGE_VERSION}"
+          echo "IS_REPO=yes" >> $GITHUB_ENV
+        fi
+        # export vars and debug output
+        echo "IS_REPO: ${{ inputs.IS_REPO }}"
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
+        echo "PACKAGE_VERSION_FULL=${{ inputs.PACKAGE_VERSION }}" >> $GITHUB_ENV
+        echo "PACKAGE_VERSION: ${PACKAGE_VERSION}"
+        echo "PACKAGE_VERSION_FULL: ${PACKAGE_VERSION_FULL}"
+    - name: Run update script
+      shell: bash
+      run: |
+        cd LibreELEC-pr/
+        echo "running update for package..."
+        echo "package name: ${{ inputs.PACKAGE_NAME }}"
+        echo "package version: ${{ env.PACKAGE_VERSION_FULL }}"
+        echo "is repo: ${{ inputs.IS_REPO }}"
+        echo "$IS_REPO"
+        if [[ "${IS_REPO}" == "yes" ]]; then
+          echo "--------111111111----------"
+          ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}"
+        else
+          echo "--------222222222----------"
+          ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}" "$PACKAGE_VERSION_FULL"
+        fi
+    - name: Push branch
+      shell: bash
+      run: |
+        cd LibreELEC-pr/
+        # git config user.name "CvH"
+        # git config user.email "CvH@users.noreply.github.com"
+        git checkout -b "pr-automated/${{ inputs.PACKAGE_NAME }}-${PACKAGE_VERSION}"
+        git remote set-url origin https://x-access-token:${LEBOT_TOKEN}@github.com/LibreELECBot/LibreELEC.tv.git
+        git push -f origin "pr-automated/${{ inputs.PACKAGE_NAME }}-${PACKAGE_VERSION}"
+    - name: Create Pull Request
+      shell: bash
+      run: |
+        cd LibreELEC-pr/
+        # get the LE base version
+        LE_VERSION=$(sed -nE 's/^[[:space:]]*OS_VERSION="([^"]+)".*/\1/p' distributions/LibreELEC/version)
+        # create the pr
+        gh pr create \
+          --repo LibreELEC/LibreELEC.tv \
+          --base master \
+          --head "LibreELECBot:pr-automated/${{ inputs.PACKAGE_NAME }}-${PACKAGE_VERSION}" \
+          --title "[LE${LE_VERSION}] ${{ inputs.PACKAGE_NAME }}: update to ${PACKAGE_VERSION}" \
+          --body "Automated update of ${{ inputs.PACKAGE_NAME }} to version ${PACKAGE_VERSION} using tools/update-pkg."

--- a/.github/workflows/check_package_update_trigger_update_workflow.yml
+++ b/.github/workflows/check_package_update_trigger_update_workflow.yml
@@ -1,0 +1,73 @@
+name: check for package update and trigger update workflow
+on:
+  workflow_dispatch:
+    inputs:
+      TEST_RUN:
+        description: 'just do a test run'
+        required: true
+        type: boolean
+        default: true
+jobs:
+  check-package-update:
+    runs-on: ubuntu-24.04
+    # Hard stop if not running in the intended repository
+    if: github.repository == 'LibreELEC/actions'
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          repository: LibreELEC/LibreELEC.tv
+          path: LibreELEC-upstream
+      - name: Check for package update
+        id: set-matrix
+        shell: bash
+        run: |
+          cd LibreELEC-upstream/
+          # run the update-scan script to get list of updated packages
+          updated_packages=$(bash tools/update-scan autoupdate=yes)
+          # debug output
+          echo "updated packages:"
+          echo "-----"
+          echo "$updated_packages"
+          echo "-----"
+          pair=$(echo "$updated_packages" | jq -Rn -c '[inputs | split(" ")] | map({ name: .[0], version: .[1] })')
+          echo "matrix=$pair" >> $GITHUB_OUTPUT
+      - name: Job summary
+        shell: bash
+        run: |
+          echo "### 📌 Updating these Packages" >> $GITHUB_STEP_SUMMARY
+          {
+            # Use jq to output a markdown table
+            echo "| Package | Version |"
+            echo "|---------|---------|"
+            echo '${{ steps.set-matrix.outputs.matrix }}' | jq -r '.[] | "| \(.name) | \(.version) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+  call-package-update:
+    if: ${{ github.event.inputs.TEST_RUN == 'false' }}
+    needs: check-package-update
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.check-package-update.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          repository: LibreELEC/actions
+      - name: Debug output
+        run: |
+          echo "Package:  ${{ matrix.name }}"
+          echo "Version:  ${{ matrix.version }}"
+      - name: Call composite function
+        uses: ./.github/actions/package_version_bump_and_pr_changes
+        env:
+          GH_TOKEN: ${{ secrets.LEBOT_PAT }}
+          LEBOT_TOKEN: ${{ secrets.LEBOT_PAT }}
+        with:
+          PACKAGE_NAME: ${{ matrix.name }}
+          PACKAGE_VERSION: ${{ matrix.version }}
+          GIT_TOKEN: ${{ secrets.LEBOT_PAT }}

--- a/.github/workflows/check_repo_update_trigger_update_workflow.yml
+++ b/.github/workflows/check_repo_update_trigger_update_workflow.yml
@@ -1,0 +1,91 @@
+name: check for repo update and trigger update workflow
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "select a repository"
+        required: true
+        type: choice
+        options:
+          - LibreELEC/amlogic-boot-fip
+          - LibreELEC/brcmfmac_sdio-firmware
+          - LibreELEC/dt-overlays
+          - LibreELEC/dvb-firmware
+          - LibreELEC/eventlircd
+          - LibreELEC/iwlwifi-firmware
+          - LibreELEC/meson-firmware
+          - LibreELEC/misc-firmware
+          - LibreELEC/script.config.vdr
+          - LibreELEC/service.libreelec.settings
+          - LibreELEC/wlan-firmware
+jobs:
+  check-package-update:
+    runs-on: ubuntu-24.04
+    # Hard stop if not running in the intended repository
+    if: github.repository == 'LibreELEC/actions'
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          repository: LibreELEC/LibreELEC.tv
+          path: LibreELEC-upstream
+      - name: Get latest commit hash from the repository
+        env:
+          REPO: ${{ github.event.inputs.repository }}
+        id: set-matrix
+        shell: bash
+        run: |
+          echo "Selected repo: $REPO"
+          REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+          # if repo name is not package name, map it accordingly
+          case "$REPO" in
+            "LibreELEC/service.libreelec.settings")
+              REPO_NAME="LibreELEC-settings"
+              ;;
+          esac
+          echo "---"
+          updated_packages="${REPO_NAME}"
+          echo $updated_packages
+          echo "---"
+          pair=$(echo "$updated_packages" | jq -Rn -c '[inputs | split(" ")] | map({ name: .[0], version: (.[1] // "") })')
+          echo "matrix=$pair" >> $GITHUB_OUTPUT
+          echo $pair
+      - name: Job summary
+        shell: bash
+        run: |
+          echo "### 📌 Updating these Packages" >> $GITHUB_STEP_SUMMARY
+          {
+            # Use jq to output a markdown table
+            echo "| Package | Version |"
+            echo "|---------|---------|"
+            echo '${{ steps.set-matrix.outputs.matrix }}' | jq -r '.[] | "| \(.name) | \(.version) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+  call-package-update:
+    needs: check-package-update
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.check-package-update.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          repository: LibreELEC/actions
+      - name: Debug output
+        run: |
+          echo "Package:  ${{ matrix.name }}"
+          echo "Version:  ${{ matrix.version }}"
+      - name: Call composite function
+        uses: ./.github/actions/package_version_bump_and_pr_changes
+        env:
+          GH_TOKEN: ${{ secrets.LEBOT_PAT }}
+          LEBOT_TOKEN: ${{ secrets.LEBOT_PAT }}
+        with:
+          PACKAGE_NAME: ${{ matrix.name }}
+          PACKAGE_VERSION: ${{ matrix.version }}
+          IS_REPO: yes
+          GIT_TOKEN: ${{ secrets.LEBOT_PAT }}


### PR DESCRIPTION
This adds the workflow to update repo and packages automatically and create PR to LE/LE repository. 
I tried to not mess up the LibreELEC/LibreELEC.tv repo by proxy everything at LibreELECBot.
Action at LibreELEC/action, push changes/branch to LibreELECBot/LE, pr to LibreELEC/LibreELEC.tv/

things that could get improved:
- check_package_update_trigger_update_workflow.yml and check_repo_update_trigger_update_workflow.yml could be combined function wise it does not matter
- if all packages are up to date is not properly handled at the moment, it just errors out because the tools/update-pkg cant handle it
- add more GHA overviews for possible scenarios to have all info directly instead of looking through logs 
- add labels at the PR, this needs some permission I didnt found

problems:
The "user" LibreELEC needs rights at LibreELECBot to push anything, Token is not enough. LibreELEC is likely not a normal user anymore (need to check with someone with access to LE user) so not sure if we can fix this easily. So maybe we need to host a spare repo at LE/spare-LE.
Cant really try this without merging :)