### PR TITLE
Adjust the package update workflow for the LE Org

### DIFF
--- a/.github/actions/package_version_bump_and_pr_changes/action.yml
+++ b/.github/actions/package_version_bump_and_pr_changes/action.yml
@@ -1,105 +1,145 @@
+name: automated-package-update
+description: Update package version and create a pull request
+
 inputs:
   PACKAGE_NAME:
-    description: "package name to update"
+    description: Package name to update
     required: true
   PACKAGE_VERSION:
-    description: "version to update to"
+    description: Version to update to
     required: false
   IS_REPO:
-    description: "is this a repository update?"
+    description: Whether this is a repository update (use "yes" for date-based versioning)
     required: false
-  app-id:
-    description: "GitHub App ID"
+  GH_APP_ID:
+    description: GitHub App ID for authentication
     required: true
-  private-key:
-    description: "GitHub App private key"
+  GH_PRIVATE_KEY:
+    description: GitHub App private key
     required: true
-name: automated-package-update
-description: "Update package version and create a pull request"
+
 runs:
-  using: "composite"
+  using: composite
   steps:
-    - name: Checkout repository
+    - name: Create GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ inputs.GH_APP_ID }}
+        private-key: ${{ inputs.GH_PRIVATE_KEY }}
+        owner: LibreELEC
+
+    - name: Checkout pr-actions repository
       uses: actions/checkout@v6
       with:
-        fetch-depth: 1
-        persist-credentials: false
-        repository: LibreELEC/LibreELEC.tv
+        repository: LibreELEC/pr-actions-fork
         ref: master
-        path: LibreELEC-pr/
-    - name: Generate GitHub App token
-      id: app-token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.private-key }}
-        owner: LibreELEC
-        repositories: pr-actions
+        token: ${{ steps.app-token.outputs.token }}
+        path: pr-actions-fork
+
+    - name: Get GitHub App User ID
+      id: get-user-id
+      shell: bash
+      run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
     - name: Configure git
       shell: bash
+      working-directory: pr-actions-fork
       run: |
-        cd LibreELEC-pr/
-        git config user.name "LibreELECBot"
-        git config user.email "LibreELECBot@users.noreply.github.com"
+        git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+        git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
     - name: Normalize version
       shell: bash
+      working-directory: pr-actions-fork
       run: |
-        cd LibreELEC-pr/
-        # shorten the version if it is a git sha256 hash
-        # add a full version variable as well
+        # Shorten version if it is a git SHA-256 hash; also set full version variable
         PACKAGE_VERSION="${{ inputs.PACKAGE_VERSION }}"
         PACKAGE_VERSION_FULL="${{ inputs.PACKAGE_VERSION }}"
         if [[ "${PACKAGE_VERSION}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-          # Git SHA-256 hash to short hash
           PACKAGE_VERSION="${PACKAGE_VERSION:0:7}"
         fi
-        # if IS_REPO is true use date as versioning
         if [[ "${{ inputs.IS_REPO }}" == "yes" ]]; then
           PACKAGE_VERSION="$(date '+%Y%m%d-%H%M%S')"
           PACKAGE_VERSION_FULL="${PACKAGE_VERSION}"
           echo "IS_REPO=yes" >> $GITHUB_ENV
         fi
-        # export vars and debug output
         echo "IS_REPO: ${{ inputs.IS_REPO }}"
         echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
         echo "PACKAGE_VERSION_FULL=${{ inputs.PACKAGE_VERSION }}" >> $GITHUB_ENV
         echo "PACKAGE_VERSION: ${PACKAGE_VERSION}"
         echo "PACKAGE_VERSION_FULL: ${PACKAGE_VERSION_FULL}"
+
     - name: Run update script
       shell: bash
+      working-directory: pr-actions-fork
       run: |
-        cd LibreELEC-pr/
         echo "running update for package..."
         echo "package name: ${{ inputs.PACKAGE_NAME }}"
         echo "package version: ${{ env.PACKAGE_VERSION_FULL }}"
         echo "is repo: ${{ inputs.IS_REPO }}"
-        echo "$IS_REPO"
         if [[ "${IS_REPO}" == "yes" ]]; then
           ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}"
         else
           ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}" "$PACKAGE_VERSION_FULL"
         fi
-    - name: Push branch to pr-actions
+
+    - name: Push branch to pr-actions-fork
+      shell: bash
+      working-directory: pr-actions-fork
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      shell: bash
       run: |
-        cd LibreELEC-pr/
         git checkout -b "pr-automated/${{ inputs.PACKAGE_NAME }}-${PACKAGE_VERSION}"
-        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/LibreELEC/pr-actions.git
         git push -f origin "pr-automated/${{ inputs.PACKAGE_NAME }}-${PACKAGE_VERSION}"
-    - name: Create Pull Request
+
+    - name: Create Pull Request via GraphQL
+      shell: bash
+      working-directory: pr-actions-fork
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      shell: bash
       run: |
-        cd LibreELEC-pr/
-        # get the LE base version
-        LE_VERSION=$(sed -nE 's/^[[:space:]]*OS_VERSION="([^"]+)".*/\1/p' distributions/LibreELEC/version)
-        # create the pr
-        gh pr create \
-          --repo LibreELEC/LibreELEC.tv \
-          --base master \
-          --head "LibreELECBot:pr-automated/${{ inputs.PACKAGE_NAME }}-${PACKAGE_VERSION}" \
-          --title "[LE${LE_VERSION}] ${{ inputs.PACKAGE_NAME }}: update to ${PACKAGE_VERSION}" \
-          --body "Automated update of ${{ inputs.PACKAGE_NAME }} to version ${PACKAGE_VERSION} using tools/update-pkg."
+        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        echo "BRANCH=$BRANCH"
+
+        REPO_ID=$(gh api graphql -f query='
+          query {
+            repository(owner: "LibreELEC", name: "pr-actions") {
+              id
+            }
+          }' --jq '.data.repository.id')
+
+        HEAD_REPO_ID=$(gh api graphql -f query='
+          query {
+            repository(owner: "LibreELEC", name: "pr-actions-fork") {
+              id
+            }
+          }' --jq '.data.repository.id')
+
+        PKG='${{ inputs.PACKAGE_NAME }}'
+        PR_TITLE="${PKG}: update package to ${PACKAGE_VERSION}"
+        PR_BODY="${PR_TITLE}"
+
+        gh api graphql -f query='
+        mutation($repo: ID!, $headRepo: ID!, $head: String!, $base: String!, $title: String!, $body: String!) {
+          createPullRequest(input: {
+            repositoryId: $repo,
+            headRepositoryId: $headRepo,
+            baseRefName: $base,
+            headRefName: $head,
+            title: $title,
+            body: $body
+          }) {
+            pullRequest {
+              url
+            }
+          }
+        }' \
+          -f repo="$REPO_ID" \
+          -f headRepo="$HEAD_REPO_ID" \
+          -f head="$BRANCH" \
+          -f base="master" \
+          -f title="$PR_TITLE" \
+          -f body="$PR_BODY"

--- a/.github/workflows/check_package_update_trigger_update_workflow.yml
+++ b/.github/workflows/check_package_update_trigger_update_workflow.yml
@@ -1,61 +1,64 @@
-name: check for package update and trigger update workflow
+name: Check for package update and trigger update workflow
+
 on:
   workflow_dispatch:
     inputs:
       TEST_RUN:
-        description: 'just do a test run'
+        description: just do a test run without creating PRs
         required: true
         type: boolean
         default: true
+
 jobs:
   check-package-update:
     runs-on: ubuntu-24.04
-    # Hard stop if not running in the intended repository
     if: github.repository == 'LibreELEC/actions'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Checkout repository - actions
+      - name: Checkout actions repo
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
           repository: ${{ github.repository_owner }}/actions
           path: actions
-      - name: Checkout repository - LibreELEC.tv
+
+      - name: Checkout LibreELEC.tv
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
           repository: ${{ github.repository_owner }}/LibreELEC.tv
           path: LibreELEC-upstream
+
       - name: Check for package update
         id: set-matrix
         shell: bash
         run: |
           cd LibreELEC-upstream/
-          # run the update-scan script to get list of updated packages
           updated_packages=$(AUTO_UPDATE=yes tools/update-scan $(cat ../actions/packages_for_autoupdate.txt))
-          # debug output
           echo "updated packages:"
           echo "-----"
           echo "$updated_packages"
           echo "-----"
           pair=$(echo "$updated_packages" | jq -Rn -c '[inputs | split(" ")] | map({ name: .[0], version: .[2] })')
           echo "matrix=$pair" >> $GITHUB_OUTPUT
+
       - name: Job summary
         shell: bash
         run: |
           echo "### 📌 Updating these Packages" >> $GITHUB_STEP_SUMMARY
           {
-            # Use jq to output a markdown table
             echo "| Package | Version |"
             echo "|---------|---------|"
             echo '${{ steps.set-matrix.outputs.matrix }}' | jq -r '.[] | "| \(.name) | \(.version) |"'
           } >> "$GITHUB_STEP_SUMMARY"
+
   call-package-update:
     if: ${{ github.event.inputs.TEST_RUN == 'false' }}
     needs: check-package-update
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.check-package-update.outputs.matrix) }}
     steps:
@@ -64,15 +67,16 @@ jobs:
         with:
           fetch-depth: 1
           repository: ${{ github.repository_owner }}/actions
-      - name: Debug output
+
+      - name: Log matrix entry
         run: |
           echo "Package:  ${{ matrix.name }}"
           echo "Version:  ${{ matrix.version }}"
-      - name: Call composite function
+
+      - name: Package version bump and PR
         uses: ./.github/actions/package_version_bump_and_pr_changes
-        env:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
         with:
           PACKAGE_NAME: ${{ matrix.name }}
           PACKAGE_VERSION: ${{ matrix.version }}
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/check_repo_update_trigger_update_workflow.yml
+++ b/.github/workflows/check_repo_update_trigger_update_workflow.yml
@@ -1,9 +1,10 @@
-name: check for repo update and trigger update workflow
+name: Check for repo update and trigger update workflow
+
 on:
   workflow_dispatch:
     inputs:
       repository:
-        description: "select a repository"
+        description: Repository to update
         required: true
         type: choice
         options:
@@ -18,55 +19,53 @@ on:
           - LibreELEC/script.config.vdr
           - LibreELEC/service.libreelec.settings
           - LibreELEC/wlan-firmware
+
 jobs:
   check-package-update:
     runs-on: ubuntu-24.04
-    # Hard stop if not running in the intended repository
     if: github.repository == 'LibreELEC/actions'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Checkout repository
+      - name: Checkout LibreELEC.tv
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
           repository: LibreELEC/LibreELEC.tv
           path: LibreELEC-upstream
+
       - name: Get latest commit hash from the repository
-        env:
-          REPO: ${{ github.event.inputs.repository }}
         id: set-matrix
         shell: bash
+        env:
+          REPO: ${{ github.event.inputs.repository }}
         run: |
           echo "Selected repo: $REPO"
           REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-          # if repo name is not package name, map it accordingly
           case "$REPO" in
             "LibreELEC/service.libreelec.settings")
               REPO_NAME="LibreELEC-settings"
               ;;
           esac
-          echo "---"
           updated_packages="${REPO_NAME}"
-          echo $updated_packages
-          echo "---"
           pair=$(echo "$updated_packages" | jq -Rn -c '[inputs | split(" ")] | map({ name: .[0], version: (.[1] // "") })')
           echo "matrix=$pair" >> $GITHUB_OUTPUT
-          echo $pair
+
       - name: Job summary
         shell: bash
         run: |
           echo "### 📌 Updating these Packages" >> $GITHUB_STEP_SUMMARY
           {
-            # Use jq to output a markdown table
             echo "| Package | Version |"
             echo "|---------|---------|"
             echo '${{ steps.set-matrix.outputs.matrix }}' | jq -r '.[] | "| \(.name) | \(.version) |"'
           } >> "$GITHUB_STEP_SUMMARY"
+
   call-package-update:
     needs: check-package-update
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.check-package-update.outputs.matrix) }}
     steps:
@@ -75,11 +74,13 @@ jobs:
         with:
           fetch-depth: 1
           repository: LibreELEC/actions
-      - name: Debug output
+
+      - name: Log matrix entry
         run: |
           echo "Package:  ${{ matrix.name }}"
           echo "Version:  ${{ matrix.version }}"
-      - name: Call composite function
+
+      - name: Package version bump and PR
         uses: ./.github/actions/package_version_bump_and_pr_changes
         env:
           GH_TOKEN: ${{ secrets.LEBOT_PAT }}


### PR DESCRIPTION
Github organisations behave completely different to a user repository.
- there is no user token, we need to use a APP token
- to create a PR we need to use GraphQL because gh cli does not support PRs at a organisation

currently its just commits and creates a pr to the dev placeholder repos, we need to merge this sub step to allow proper testing

LE/actions -> (create branch) -> LE/pr-actions-fork -> (create pr) -> LE/pr-actions

example prs
https://github.com/LibreELEC/pr-actions/pulls