### PR TITLE
fix: pass GHA_AUTO inline to update-pkg

### DIFF
--- a/.github/actions/package_version_bump_and_pr_changes/action.yml
+++ b/.github/actions/package_version_bump_and_pr_changes/action.yml
@@ -11,6 +11,7 @@ inputs:
   IS_REPO:
     description: Whether this is a repository update (use "yes" for date-based versioning)
     required: false
+    default: no
   GH_APP_ID:
     description: GitHub App ID for authentication
     required: true
@@ -103,11 +104,9 @@ runs:
         echo "package version: ${{ env.PACKAGE_VERSION_FULL }}"
         echo "is repo: ${{ inputs.IS_REPO }}"
         if [[ "${IS_REPO}" == "yes" ]]; then
-          echo 'GHA_AUTO=false' >> "$GITHUB_ENV"
-          ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}"
+          GHA_AUTO=false ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}"
         else
-          echo 'GHA_AUTO=true' >> "$GITHUB_ENV"
-          ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}" "$PACKAGE_VERSION_FULL"
+          GHA_AUTO=true ./tools/update-pkg "${{ inputs.PACKAGE_NAME }}" "$PACKAGE_VERSION_FULL"
         fi
 
     - name: Push branch to fork


### PR DESCRIPTION
GITHUB_ENV changes only apply to subsequent steps, not the current shell. Export GHA_AUTO inline so update-pkg sees it immediately.