### PR TITLE
scripts, workflows: shellcheck and standards cleanup

### DIFF
--- a/.github/workflows/build-LE11-addons.yml
+++ b/.github/workflows/build-LE11-addons.yml
@@ -18,7 +18,7 @@ on:
           - ARMv8.arm
           - Generic.x86_64
           - Generic-legacy.x86_64
- 
+
 env:
   # these ENV variables are not used yet - need to get this working with the with statements below
   clean_le: no_clean_le

--- a/.github/workflows/build-LE12-2-addons.yml
+++ b/.github/workflows/build-LE12-2-addons.yml
@@ -18,7 +18,7 @@ on:
           - ARMv8.aarch64
           - Generic.x86_64
           - Generic-legacy.x86_64
- 
+
 env:
   # these ENV variables are not used yet - need to get this working with the with statements below
   clean_le: no_clean_le
@@ -102,7 +102,7 @@ jobs:
       ccachecachesize: 20G
       version: "12.2"
     secrets: inherit
-    
+
   Generic_x86_64-12_2:
     name: "Generic.x86_64 12.2"
     # Only run if there has been a commit in the last 24 hours

--- a/.github/workflows/build-LE12-addons.yml
+++ b/.github/workflows/build-LE12-addons.yml
@@ -18,7 +18,7 @@ on:
           - ARMv8.aarch64
           - Generic.x86_64
           - Generic-legacy.x86_64
- 
+
 env:
   # these ENV variables are not used yet - need to get this working with the with statements below
   clean_le: no_clean_le
@@ -102,7 +102,7 @@ jobs:
       ccachecachesize: 20G
       version: "12.0"
     secrets: inherit
-    
+
   Generic_x86_64-12_0:
     name: "Generic.x86_64 12.0"
     # Only run if there has been a commit in the last 24 hours

--- a/.github/workflows/build-LE13-addons.yml
+++ b/.github/workflows/build-LE13-addons.yml
@@ -21,7 +21,7 @@ on:
   schedule:
     # The times are specified in UTC
     - cron: "15 3 * * *"
- 
+
 env:
   # these ENV variables are not used yet - need to get this working with the with statements below
   clean_le: no_clean_le
@@ -105,7 +105,7 @@ jobs:
       ccachecachesize: 20G
       version: "13.0"
     secrets: inherit
-    
+
   Generic_x86_64-13_0:
     name: "Generic.x86_64 13.0"
     # Only run if there has been a commit in the last 24 hours

--- a/.github/workflows/clean-img.yml
+++ b/.github/workflows/clean-img.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Remove old image files in the test.libreelec.tv directory
         if: |
-          (github.event.inputs.run_clean == 'run_clean') || 
-          (github.event.workflow_run.event == 'schedule') || 
+          (github.event.inputs.run_clean == 'run_clean') ||
+          (github.event.workflow_run.event == 'schedule') ||
           (github.event.workflow_run.event == 'workflow_dispatch')
         run: |
           ssh -p ${{ secrets.NIGHTLY_HOST_PORT }} ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} \

--- a/.github/workflows/clean-img.yml
+++ b/.github/workflows/clean-img.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   clean_img:
     runs-on: [self-hosted, scripts]
+    if: github.repository == 'LibreELEC/actions'
 
     steps:
       - name: log variables

--- a/.github/workflows/update-cacert-pem-certificate-bundle.yml
+++ b/.github/workflows/update-cacert-pem-certificate-bundle.yml
@@ -13,6 +13,7 @@ jobs:
   update-cacert-pem-certificate-bundle:
     name: Update cacert.pem certificate bundle
     runs-on: ubuntu-latest
+    if: github.repository == 'LibreELEC/actions'
     env:
       CERTDATA_OWNER: mozilla-firefox
       CERTDATA_REPO: firefox

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
 set -e
 
 # set version to use

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -45,6 +45,7 @@ rsync_log () {
   printf "*Updated Add-ons* \n"
 
   # list Add-ons
+  # shellcheck disable=SC2034  # addon names the field for readability; it is not used in the loop body
   while IFS="/" read -r project platform addon filename; do
     if [[ $project_rsync != $project$platform ]]; then
       printf '%s %s %s' "\n*$project" "$platform" "($REPO_VERSION) *\n"   # some crap due the slack function escape text
@@ -120,6 +121,7 @@ done
 # rename and move files to files
 for PROJECT in "$PATH_STAGING"/*.zip; do
   PROJECT=$(basename "$PROJECT")
+  # shellcheck disable=SC2034  # var1 documents the field layout; it is not used further
   var1=$(echo "$PROJECT" | cut -d- -f1 )                             # 9.0
   var2=$(echo "$PROJECT" | cut -d- -f2 )                             # Generic
   var3=$(echo "$PROJECT" | cut -d- -f3 )                             # Could be either ARCH (x86_64) or legacy

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -116,13 +116,13 @@ for PROJECT in "$PATH_STAGING"/*.zip; do
     else
       # remove files that fail at checksum test
       mv "$PROJECT" "$PROJECT"-ohohhhhh
-      slack "*WARNING:* $(basename "$PROJECT") wrong checksum \n"
+      slack "*WARNING:* ${PROJECT##*/} wrong checksum \n"
     fi
 done
 
 # rename and move files to files
 for PROJECT in "$PATH_STAGING"/*.zip; do
-  PROJECT=$(basename "$PROJECT")
+  PROJECT="${PROJECT##*/}"
   # shellcheck disable=SC2034  # var1 documents the field layout; it is not used further
   var1=$(echo "$PROJECT" | cut -d- -f1 )                             # 9.0
   var2=$(echo "$PROJECT" | cut -d- -f2 )                             # Generic

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # set version to use
 # check for format 9.2.0 instead of 9.2
 if [[ "$1" =~ ^[0-9]{1,2}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -58,27 +58,24 @@ rsync_log () {
 
 # create addon.xml
 create_addon_xml(){
-  for PROJECT in $(find "$PATH_ADDON_REPO"/* -maxdepth 0 -type d); do
-    PROJECT=$(basename "$PROJECT")
-    for ARCH in $(find "$PATH_ADDON_REPO/$PROJECT"/* -maxdepth 0 -type d); do
-      ARCH=$(basename "$ARCH")
+  while IFS= read -r PROJECT; do
+    while IFS= read -r ARCH; do
       ARCH_XML='<?xml version="1.0" encoding="UTF-8"?>\n<addons>\n'
-      for ADDON in $(find "$PATH_ADDON_REPO/$PROJECT/$ARCH"/* -maxdepth 0 -type d); do
-        ADDON=$(basename "$ADDON")
-        for ARCHIVE in $(find "$PATH_ADDON_REPO/$PROJECT/$ARCH/$ADDON" -type f -name "*.zip" | sort -V); do
+      while IFS= read -r ADDON; do
+        while IFS= read -r ARCHIVE; do
           if [ -n "$ARCHIVE" ]; then
             ARCHIVE_XML=$(unzip -pv "$ARCHIVE" "$ADDON/addon.xml" | sed '1d' | cat)
             ARCH_XML="$ARCH_XML$ARCHIVE_XML\n"
           fi
-        done
-      done
+        done < <(find "$PATH_ADDON_REPO/$PROJECT/$ARCH/$ADDON" -type f -name "*.zip" | sort -V)
+      done < <(find "$PATH_ADDON_REPO/$PROJECT/$ARCH" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
       ARCH_XML="$ARCH_XML</addons>"
       echo -e "$ARCH_XML" > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml"
       gzip -f "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml"
       md5sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.md5"
       sha256sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.sha256"
-    done
-  done
+    done < <(find "$PATH_ADDON_REPO/$PROJECT" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+  done < <(find "$PATH_ADDON_REPO" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 }
 
 ###############

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -93,7 +93,7 @@ fi
 mkdir -p "$PATH_TARGET" "$PATH_ADDON_REPO"
 
 # check for enough free disk space
-if [ $(df "$PATH_ADDON_REPO" | awk 'END {print $4}') -lt 6000000 ]; then
+if [[ $(df "$PATH_ADDON_REPO" | awk 'END {print $4}') -lt 6000000 ]]; then
   slack "*WARNING*: not enough storage is available\n\`\`\`$(df "$PATH_ADDON_REPO")\`\`\`"
   exit 0;
 fi
@@ -156,7 +156,7 @@ create_addon_xml
 
 # post to slack
 if [ -s "$PATH_LOG" ]; then
-  slack $(rsync_log)
+  slack "$(rsync_log)"
 fi
 
 exit 0

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -47,10 +47,11 @@ rsync_log () {
   printf "*Updated Add-ons* \n"
 
   # list Add-ons
-  # shellcheck disable=SC2034  # addon names the field for readability; it is not used in the loop body
+  # shellcheck disable=SC2034  # addon: kept for readability, unused in loop body
   while IFS="/" read -r project platform addon filename; do
     if [[ $project_rsync != $project$platform ]]; then
-      printf '%s %s %s' "\n*$project" "$platform" "($REPO_VERSION) *\n"   # some crap due the slack function escape text
+      # some crap due the slack function escape text
+      printf '%s %s %s' "\n*$project" "$platform" "($REPO_VERSION) *\n"
       printf ' %s' "${filename%.*}\n"
     else
       printf ' %s' "${filename%.*}\n"
@@ -75,8 +76,10 @@ create_addon_xml(){
       ARCH_XML="$ARCH_XML</addons>"
       echo -e "$ARCH_XML" > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml"
       gzip -f "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml"
-      md5sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.md5"
-      sha256sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.sha256"
+      md5sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" \
+        | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.md5"
+      sha256sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" \
+        | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.sha256"
     done < <(find "$PATH_ADDON_REPO/$PROJECT" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
   done < <(find "$PATH_ADDON_REPO" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 }

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -34,7 +34,7 @@ slack () {
       text="$text$line\n"
     done
   fi
-  escapedText=$(echo $text | sed 's/"/\"/g' | sed "s/'/\'/g" )
+  escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g" )
   json="{\"channel\": \"$slack_channel\", \"username\":\"$username\", \"icon_emoji\":\"ghost\", \"attachments\":[{\"color\":\"$color\" , \"text\": \"$escapedText\"}]}"
   curl -s -d "payload=$json" "$slack_webhook_url"
 }
@@ -60,12 +60,12 @@ rsync_log () {
 create_addon_xml(){
   for PROJECT in $(find "$PATH_ADDON_REPO"/* -maxdepth 0 -type d); do
     PROJECT=$(basename "$PROJECT")
-    for ARCH in $(find "$PATH_ADDON_REPO"/$PROJECT/* -maxdepth 0 -type d); do
+    for ARCH in $(find "$PATH_ADDON_REPO/$PROJECT"/* -maxdepth 0 -type d); do
       ARCH=$(basename "$ARCH")
       ARCH_XML='<?xml version="1.0" encoding="UTF-8"?>\n<addons>\n'
-      for ADDON in $(find "$PATH_ADDON_REPO"/$PROJECT/$ARCH/* -maxdepth 0 -type d); do
+      for ADDON in $(find "$PATH_ADDON_REPO/$PROJECT/$ARCH"/* -maxdepth 0 -type d); do
         ADDON=$(basename "$ADDON")
-        for ARCHIVE in $(find "$PATH_ADDON_REPO"/$PROJECT/$ARCH/$ADDON -type f -name "*.zip" | sort -V); do
+        for ARCHIVE in $(find "$PATH_ADDON_REPO/$PROJECT/$ARCH/$ADDON" -type f -name "*.zip" | sort -V); do
           if [ -n "$ARCHIVE" ]; then
             ARCHIVE_XML=$(unzip -pv "$ARCHIVE" "$ADDON/addon.xml" | sed '1d' | cat)
             ARCH_XML="$ARCH_XML$ARCHIVE_XML\n"
@@ -73,10 +73,10 @@ create_addon_xml(){
         done
       done
       ARCH_XML="$ARCH_XML</addons>"
-      echo -e "$ARCH_XML" > "$PATH_ADDON_REPO"/$PROJECT/$ARCH/addons.xml
-      gzip -f "$PATH_ADDON_REPO"/$PROJECT/$ARCH/addons.xml
-      md5sum "$PATH_ADDON_REPO"/$PROJECT/$ARCH/addons.xml.gz | cut -f1 -d ' ' > "$PATH_ADDON_REPO"/$PROJECT/$ARCH/addons.xml.gz.md5
-      sha256sum "$PATH_ADDON_REPO"/$PROJECT/$ARCH/addons.xml.gz | cut -f1 -d ' ' > "$PATH_ADDON_REPO"/$PROJECT/$ARCH/addons.xml.gz.sha256
+      echo -e "$ARCH_XML" > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml"
+      gzip -f "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml"
+      md5sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.md5"
+      sha256sum "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz" | cut -f1 -d ' ' > "$PATH_ADDON_REPO/$PROJECT/$ARCH/addons.xml.gz.sha256"
     done
   done
 }
@@ -90,11 +90,11 @@ if [ ! -d "$PATH_STAGING" ]; then
 fi
 
 # preparing folder
-mkdir -p $PATH_TARGET $PATH_ADDON_REPO
+mkdir -p "$PATH_TARGET" "$PATH_ADDON_REPO"
 
 # check for enough free disk space
-if [ $(df $PATH_ADDON_REPO | awk 'END {print $4}') -lt 6000000 ]; then
-  slack "*WARNING*: not enough storage is available\n\`\`\`$(df $PATH_ADDON_REPO)\`\`\`"
+if [ $(df "$PATH_ADDON_REPO" | awk 'END {print $4}') -lt 6000000 ]; then
+  slack "*WARNING*: not enough storage is available\n\`\`\`$(df "$PATH_ADDON_REPO")\`\`\`"
   exit 0;
 fi
 
@@ -111,12 +111,12 @@ mkdir -p "$PATH_TARGET"
 # check for sha256sum
 for PROJECT in "$PATH_STAGING"/*.zip; do
   cd "$PATH_STAGING" || exit
-    if sha256sum --status -c $PROJECT.sha256 2>&1; then
+    if sha256sum --status -c "$PROJECT.sha256" 2>&1; then
       continue;
     else
       # remove files that fail at checksum test
       mv "$PROJECT" "$PROJECT"-ohohhhhh
-      slack "*WARNING:* $(basename $PROJECT) wrong checksum \n"
+      slack "*WARNING:* $(basename "$PROJECT") wrong checksum \n"
     fi
 done
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
 # abort at error
 set -e
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -35,7 +35,12 @@ EOF
     var_hash="$(grep -oP '(?<=^"[0-9-]{10} )[0-9a-f]{7}' <<<"$line")"
 
     # output line
-    echo "<tr><td>$var_date ($var_hash):</td><td><a href=\"https://github.com/LibreELEC/LibreELEC.tv/pull/${var_pr//#/}\" target=\"_blank\" rel=\"noopener noreferrer\">${var_pr}</a></td><td>${var_message}</td></tr>"
+    url="https://github.com/LibreELEC/LibreELEC.tv/pull/${var_pr//#/}"
+    row="<tr><td>$var_date ($var_hash):</td>"
+    row+="<td><a href=\"$url\" target=\"_blank\""
+    row+=" rel=\"noopener noreferrer\">${var_pr}</a></td>"
+    row+="<td>${var_message}</td></tr>"
+    echo "$row"
   done <<<"$gh_output"
 
   # html footer

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -35,7 +35,7 @@ EOF
     var_hash="$(grep -oP '(?<=^"[0-9-]{10} )[0-9a-f]{7}' <<<"$line")"
 
     # output line
-    echo "<tr><td>$var_date ($var_hash):</td><td><a href=\"https://github.com/LibreELEC/LibreELEC.tv/pull/${var_pr//#/}\" target="_blank" rel="noopener noreferrer">${var_pr}</a></td><td>${var_message}</td></tr>"
+    echo "<tr><td>$var_date ($var_hash):</td><td><a href=\"https://github.com/LibreELEC/LibreELEC.tv/pull/${var_pr//#/}\" target=\"_blank\" rel=\"noopener noreferrer\">${var_pr}</a></td><td>${var_message}</td></tr>"
   done <<<"$gh_output"
 
   # html footer


### PR DESCRIPTION
Linting and standards pass over the shell scripts and workflow files, following STANDARDS.md from LibreELEC/LibreELEC.tv.
- Manual lint against STANDARDS.md
- shellcheck of the shell scripts
- restrict the actions to only running in the LibreELEC/actions repository (they don't work in forks)
- only remaining STANDARDS task is: `${VAR}` not `$VAR` required throughout: which will be addressed in a future PR. 