### PR TITLE
workflows: notify Slack on failed addon and image builds

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -218,6 +218,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed addon builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -218,6 +218,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed addon builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -216,6 +216,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed addon builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -218,6 +218,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed addon builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -216,6 +216,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed addon builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -228,6 +228,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed image builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -228,6 +228,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed image builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -229,6 +229,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed image builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -230,6 +230,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed image builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -229,6 +229,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
+      - name: Notify failed image builds
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
+          if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
+            joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          else
+            joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
+          fi
+          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
+          if [ -z "${failed}" ]; then exit 0; fi
+          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r pkg; do
+            text+="${pkg}\n"
+          done <<< "${failed}"
+          json="{\"channel\": \"${SLACK_CHANNEL}\","
+          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
+          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+
       - name: Clean up - remove docker image tag
         run: |
           cd LibreELEC.tv


### PR DESCRIPTION
## Summary
- Add a Notify failed addon builds step to all 5 yml-uses-create-addon-*.yml reusable workflows
- Add a Notify failed image builds step to all 5 yml-uses-make-image-*.yml reusable workflows

Both steps parse .threads/joblog for ^FAIL entries after the build completes and POST the list of failed packages to Slack via ADDONS_REPO_WEBHOOK_URL / ADDONS_REPO_WEBHOOK_CHANNEL. The step exits cleanly with no side-effects when no webhook is configured or when there are no build failures.

## Notes
- Requires no changes to calling workflows — secrets: inherit is already in place
- Mirrors the pattern already used by update_addon_repo.sh for deploy notifications