### PR TITLE
update_addon_repo: exit cleanly when no add-on zips are staged

### DIFF
--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -95,6 +95,9 @@ if [ ! -d "${PATH_STAGING}" ]; then
   exit 0;
 fi
 
+# exit cleanly if no add-on zips are staged
+compgen -G "${PATH_STAGING}*.zip" > /dev/null 2>&1 || exit 0
+
 # preparing folder
 mkdir -p "${PATH_TARGET}" "${PATH_ADDON_REPO}"
 


### PR DESCRIPTION
set -e added in ae9f9e6 exposed a latent bug: when the staging directory exists but contains no .zip files, the for loop receives the unexpanded glob literal, sha256sum fails, mv on the non-existent path fails, and set -e exits 1. Add a compgen -G guard to exit 0 before any side-effects when nothing is staged.