### PR TITLE
yml-uses-make-image/create-addon: always clean up docker image tag

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -219,6 +219,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -219,6 +219,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -217,6 +217,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -219,6 +219,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -217,6 +217,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -229,6 +229,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -229,6 +229,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -230,6 +230,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -231,6 +231,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -230,6 +230,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Clean up - remove docker image tag
+        if: always()
         run: |
           cd LibreELEC.tv
           docker image rm -f gh-${{ github.run_id }}


### PR DESCRIPTION
Add if: always() to the "Clean up - remove docker image tag" step so it runs even when the job fails or is cancelled, preventing orphaned gh-<run_id> image tags from accumulating on build hosts.