### PR TITLE
yml-uses: enrich Slack failure notifications with step and reason

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -229,16 +229,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -229,16 +229,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -227,16 +227,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -229,16 +229,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -227,16 +227,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_ADDON_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -239,16 +239,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -239,16 +239,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -240,16 +240,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -241,16 +241,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -240,16 +240,29 @@ jobs:
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
-          failed=$(grep ^FAIL "${joblog}" 2>/dev/null | awk '{ print $5 }' | tr ':' '_' || true)
-          if [ -z "${failed}" ]; then exit 0; fi
-          text="*Build failures - ${{ env.PROJECT }}.${{ env.ARCH }} (${LE_DISTRO_VERSION}):*\n"
-          while IFS= read -r pkg; do
-            text+="${pkg}\n"
-          done <<< "${failed}"
+          failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
+          if [ -z "${failed_lines}" ]; then exit 0; fi
+          artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
+          device="${{ env.DEVICE }}"
+          title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
+          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          while IFS= read -r line; do
+            step=$(echo "${line}" | awk '{ print $2 }')
+            pkg=$(echo "${line}" | awk '{ print $5 }')
+            logpath=$(echo "${line}" | awk '{ print $12 }')
+            pkgsafe="${pkg//:/_}"
+            logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
+            text+="step ${step} ${pkg}\n"
+            if [ -f "${logfile}" ]; then
+              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
+            fi
+          done <<< "${failed_lines}"
+          text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
           json="{\"channel\": \"${SLACK_CHANNEL}\","
           json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
           json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}"
+          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
 
       - name: Clean up - remove docker image tag
         if: always()


### PR DESCRIPTION
- Show package:type (e.g. linux:host) instead of mangled linux_host
- Include DEVICE in title when set (e.g. Rockchip.RK3588.aarch64)
- Add clickable run link so failures are one click away
- Guard curl with || true so a Slack outage cannot fail the step

For each failed package in the joblog:
- Show step number [024/306] and package linux:host
- Read the artifact log and extract failure reason (APPLY PATCH, CONFIGURE, CMAKE, UNPACK) when available

Message format:
```
  step [024/306]
  linux:host
  reason for failure - APPLY PATCH
  View run
```