### PR TITLE
yml-uses: switch Slack notifications to slackapi/slack-github-action@v3

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -218,28 +218,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed addon builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed addon build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -249,10 +249,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed addon builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -231,6 +231,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -241,7 +242,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -218,28 +218,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed addon builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed addon build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -249,10 +249,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed addon builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -231,6 +231,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -241,7 +242,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -229,6 +229,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -239,7 +240,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -216,28 +216,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed addon builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed addon build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -247,10 +247,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed addon builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -218,28 +218,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed addon builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed addon build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -249,10 +249,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed addon builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -231,6 +231,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -241,7 +242,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -229,6 +229,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -239,7 +240,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -216,28 +216,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed addon builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed addon build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -247,10 +247,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed addon builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -228,28 +228,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed image builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed image build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -259,10 +259,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed image builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -241,6 +241,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -251,7 +252,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -228,28 +228,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed image builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed image build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -259,10 +259,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed image builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -241,6 +241,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -251,7 +252,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -242,6 +242,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -252,7 +253,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -229,28 +229,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed image builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed image build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -260,10 +260,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed image builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -230,28 +230,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed image builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed image build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -261,10 +261,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed image builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -243,6 +243,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -253,7 +254,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -242,6 +242,7 @@ jobs:
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
           if [ -z "${failed_lines}" ]; then exit 0; fi
+          total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
@@ -252,7 +253,7 @@ jobs:
             logpath=$(echo "${line}" | awk '{ print $12 }')
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
-            text+="step ${step} ${pkg}\n"
+            text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
               reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -229,28 +229,28 @@ jobs:
           path: ${{ env.BASEDIR }}/build-root/${{ env.TARGETBUILDDIR }}/artifact/
           if-no-files-found: ignore
 
-      - name: Notify failed image builds
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}
+      - name: Collect failed image build information
+        id: failures
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then exit 0; fi
           if [ "${{ inputs.ephemeral }}" = "ephemeral" ]; then
             joblog="LibreELEC.tv/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           else
             joblog="${BASEDIR}/build-root/${{ env.TARGETBUILDDIR }}/.threads/joblog"
           fi
           failed_lines=$(grep ^FAIL "${joblog}" 2>/dev/null || true)
-          if [ -z "${failed_lines}" ]; then exit 0; fi
+          if [ -z "${failed_lines}" ]; then
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
           text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
           while IFS= read -r line; do
-            step=$(echo "${line}" | awk '{ print $2 }')
-            pkg=$(echo "${line}" | awk '{ print $5 }')
-            logpath=$(echo "${line}" | awk '{ print $12 }')
+            step=$(awk '{ print $2 }' <<< "${line}")
+            pkg=$(awk '{ print $5 }' <<< "${line}")
+            logpath=$(awk '{ print $12 }' <<< "${line}")
             pkgsafe="${pkg//:/_}"
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
@@ -260,10 +260,26 @@ jobs:
             fi
           done <<< "${failed_lines}"
           text+="<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-          json="{\"channel\": \"${SLACK_CHANNEL}\","
-          json+=" \"username\": \"ADDON Bot\", \"icon_emoji\": \"ghost\","
-          json+=" \"attachments\": [{\"color\": \"danger\", \"text\": \"${text}\"}]}"
-          curl -s -d "payload=${json}" "${SLACK_WEBHOOK_URL}" || true
+          {
+            echo "has_failures=true"
+            echo "text<<EOF"
+            echo "${text}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify failed image builds
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()


### PR DESCRIPTION
Replace curl-based webhook calls with slackapi/slack-github-action@v3
across all 10 yml-uses workflows. Also adds [030/306] step counter
format and splits notify into a collect + notify step pair.