### PR TITLE
yml-uses: fix step total by reading plan.json length

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -231,7 +231,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -231,7 +231,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -229,7 +229,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -231,7 +231,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -229,7 +229,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -241,7 +241,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -241,7 +241,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -242,7 +242,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -243,7 +243,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -242,7 +242,9 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          total=$(wc -l < "${joblog}" | tr -d ' ')
+          planfile="${joblog%/joblog}/plan.json"
+          total=$(python3 -c "import json; print(len(json.load(open('${planfile}'))))" 2>/dev/null)
+          [ -z "${total}" ] && total=$(wc -l < "${joblog}" | tr -d ' ')
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"


### PR DESCRIPTION
jobtotal is not written to the joblog — only the zero-padded seq is. Read total from .threads/plan.json (same dir as joblog) using python3, falling back to wc -l if the file is absent.