### PR TITLE
yml-uses-create-addon: fix Slack failure reason detection

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -246,7 +246,10 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              if [ -z "${reason}" ]; then
+                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -246,7 +246,10 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              if [ -z "${reason}" ]; then
+                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -244,7 +244,10 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              if [ -z "${reason}" ]; then
+                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -246,7 +246,10 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              if [ -z "${reason}" ]; then
+                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -244,7 +244,10 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              if [ -z "${reason}" ]; then
+                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"


### PR DESCRIPTION
Use tail -200 to avoid false positives from dependency build output earlier in the log. Add cannot stat fallback to surface missing shared library filenames (e.g. libx265.so.215) for addon failures that don't have a build-phase marker.