### PR TITLE
deploy-addons: structured JSON output and Slack via GHA action

### DIFF
--- a/.github/workflows/deploy-addons.yml
+++ b/.github/workflows/deploy-addons.yml
@@ -27,6 +27,7 @@ jobs:
           fetch-depth: 1
           repository: "${{ github.repository_owner }}/actions"
           path: "actions"
+
       - name: Determine addon version
         id: version
         run: |
@@ -40,12 +41,89 @@ jobs:
           addon_version=$(curl -s "https://raw.githubusercontent.com/LibreELEC/LibreELEC.tv/${branch}/distributions/LibreELEC/version" \
             | grep -oP 'ADDON_VERSION="\K[^"]+')
           echo "addon_version=${addon_version}" >> "${GITHUB_OUTPUT}"
+
       - name: Update Add-on repository
+        id: result
         run: |
-          echo "Updating Add-on version ${{ steps.version.outputs.addon_version }}"
-          cd "actions/"
-          ssh ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }} -p ${{ secrets.ADDONS_HOST_PORT }} \
-            "bash -s" < ./scripts/update_addon_repo.sh \
-              "${{ steps.version.outputs.addon_version }}" \
-              "${{ secrets.ADDONS_REPO_WEBHOOK_URL }}" \
-              "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+          output=$(ssh ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }} \
+            -p ${{ secrets.ADDONS_HOST_PORT }} \
+            "bash -s" < ./actions/scripts/update_addon_repo.sh \
+            "${{ steps.version.outputs.addon_version }}" || true)
+          [ -z "${output}" ] && exit 0
+          {
+            echo "json<<EOF"
+            echo "${output}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Format Slack messages
+        id: fmt
+        if: steps.result.outputs.json != ''
+        env:
+          RESULT_JSON: ${{ steps.result.outputs.json }}
+        run: |
+          python3 - << 'PYEOF'
+          import json, os
+
+          data = json.loads(os.environ.get('RESULT_JSON', '{}'))
+          version = data.get('version', '')
+          warnings = data.get('warnings', [])
+          architectures = data.get('architectures', [])
+          error = data.get('error', '')
+          out = os.environ['GITHUB_OUTPUT']
+
+          has_warnings = bool(error or warnings)
+          has_updates = bool(architectures)
+
+          warning_parts = []
+          if error:
+            warning_parts.append(f'*ERROR*: {error}')
+          if warnings:
+            warning_parts.append(f'*WARNING* wrong checksums ({len(warnings)} files):')
+            warning_parts.extend(f'  {w}' for w in warnings)
+          warnings_text = r'\n'.join(warning_parts)
+
+          arch_texts = []
+          for arch in architectures:
+            label = arch.get('label', '')
+            addons = arch.get('addons', [])
+            lines = [f'*Updated Add-ons - {label} ({version})*'] + [f' {a}' for a in addons]
+            arch_texts.append(r'\n'.join(lines))
+          updates_text = r'\n\n'.join(arch_texts)
+
+          with open(out, 'a') as f:
+            f.write(f'has_warnings={"true" if has_warnings else "false"}\n')
+            f.write(f'has_updates={"true" if has_updates else "false"}\n')
+            if has_warnings:
+              f.write(f'warnings_text<<EOF\n{warnings_text}\nEOF\n')
+            if has_updates:
+              f.write(f'updates_text<<EOF\n{updates_text}\nEOF\n')
+          PYEOF
+
+      - name: Notify warnings
+        if: steps.fmt.outputs.has_warnings == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: danger
+                text: "${{ steps.fmt.outputs.warnings_text }}"
+
+      - name: Notify updates
+        if: steps.fmt.outputs.has_updates == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            attachments:
+              - color: good
+                text: "${{ steps.fmt.outputs.updates_text }}"

--- a/scripts/update_addon_repo.sh
+++ b/scripts/update_addon_repo.sh
@@ -17,10 +17,6 @@ else
   exit 1
 fi
 
-# slack variables
-slack_webhook_url="$2"
-slack_channel="$3"
-
 # variables
 PATH_STAGING="/var/www/addon-upload/${REPO_VERSION}/"
 PATH_TARGET="/var/www/addon-temp/${REPO_VERSION}"
@@ -29,38 +25,52 @@ PATH_ADDON_REPO="/var/www/addons/${REPO_VERSION}"
 
 #### functions
 
-# slack notification function
-slack () {
-  username="ADDON Bot"
-  color="good" #good, warning, danger or HEX value
-  text=$*
-  if [[ ${text} == "" ]]; then
-    while IFS= read -r line; do
-      text="${text}${line}\n"
-    done
-  fi
-  escapedText=$(echo "${text}" | sed 's/"/\"/g' | sed "s/'/\'/g" )
-  json="{\"channel\": \"${slack_channel}\", \"username\":\"${username}\", \"icon_emoji\":\"ghost\", \"attachments\":[{\"color\":\"${color}\" , \"text\": \"${escapedText}\"}]}"
-  curl -s -d "payload=${json}" "${slack_webhook_url}" || true
+# emit JSON result to stdout for GHA to consume and post to Slack
+emit_result() {
+  local error_msg="${1:-}"
+  ERROR_MSG="${error_msg}" REPO_VERSION="${REPO_VERSION}" \
+  python3 - "${PATH_LOG}" "${BAD_CHECKSUMS_FILE}" << 'PYEOF'
+import json, sys, os
+
+version = os.environ.get('REPO_VERSION', '')
+error_msg = os.environ.get('ERROR_MSG', '')
+log_path, warnings_path = sys.argv[1], sys.argv[2]
+
+warnings = []
+try:
+    with open(warnings_path) as f:
+        warnings = [line.strip() for line in f if line.strip()]
+except (FileNotFoundError, OSError):
+    pass
+
+addons_by_arch = {}
+arch_order = []
+try:
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split('/')
+            if len(parts) >= 4:
+                key = f'{parts[0]} {parts[1]}'
+                if key not in addons_by_arch:
+                    addons_by_arch[key] = []
+                    arch_order.append(key)
+                filename = parts[-1]
+                addons_by_arch[key].append(filename[:-4] if filename.endswith('.zip') else filename)
+except (FileNotFoundError, OSError):
+    pass
+
+result = {
+    'version': version,
+    'warnings': warnings,
+    'architectures': [{'label': k, 'addons': addons_by_arch[k]} for k in arch_order],
 }
-
-# pretty up the rsync log
-rsync_log () {
-  # header text
-  printf "*Updated Add-ons* \n"
-
-  # list Add-ons
-  # shellcheck disable=SC2034  # addon: kept for readability, unused in loop body
-  while IFS="/" read -r project platform addon filename; do
-    if [[ ${project_rsync} != ${project}${platform} ]]; then
-      # some crap due the slack function escape text
-      printf '%s %s %s' "\n*${project}" "${platform}" "(${REPO_VERSION}) *\n"
-      printf ' %s' "${filename%.*}\n"
-    else
-      printf ' %s' "${filename%.*}\n"
-    fi
-    project_rsync=${project}${platform}
-  done < "${PATH_LOG}"
+if error_msg:
+    result['error'] = error_msg
+print(json.dumps(result))
+PYEOF
 }
 
 # create addon.xml
@@ -89,10 +99,13 @@ create_addon_xml(){
 
 ###############
 
+BAD_CHECKSUMS_FILE=$(mktemp)
+trap 'rm -f "${BAD_CHECKSUMS_FILE}"' EXIT
+
 # check if jenkins addons are available
 if [ ! -d "${PATH_STAGING}" ]; then
-  slack "*WARNING*: no jenkins addons folder exist"
-  exit 0;
+  emit_result "no staging folder for ${REPO_VERSION}"
+  exit 0
 fi
 
 # exit cleanly if no add-on zips are staged
@@ -103,8 +116,8 @@ mkdir -p "${PATH_TARGET}" "${PATH_ADDON_REPO}"
 
 # check for enough free disk space
 if [[ $(df "${PATH_ADDON_REPO}" | awk 'END {print $4}') -lt 6000000 ]]; then
-  slack "*WARNING*: not enough storage is available\n\`\`\`$(df "${PATH_ADDON_REPO}")\`\`\`"
-  exit 0;
+  emit_result "not enough storage ($(df -h "${PATH_ADDON_REPO}" | awk 'END {print $4}') free)"
+  exit 0
 fi
 
 # kill log
@@ -117,16 +130,15 @@ touch "${PATH_LOG}"
 # create target dir
 mkdir -p "${PATH_TARGET}"
 
-# check for sha256sum
+# check for sha256sum - collect failures instead of posting one-per-file
 for PROJECT in "${PATH_STAGING}"/*.zip; do
   cd "${PATH_STAGING}" || exit
-    if sha256sum --status -c "${PROJECT}.sha256" 2>&1; then
-      continue;
-    else
-      # remove files that fail at checksum test
-      mv "${PROJECT}" "${PROJECT}"-ohohhhhh
-      slack "*WARNING:* ${PROJECT##*/} wrong checksum \n"
-    fi
+  if sha256sum --status -c "${PROJECT}.sha256" 2>&1; then
+    continue
+  else
+    mv "${PROJECT}" "${PROJECT}"-ohohhhhh
+    echo "${PROJECT##*/}" >> "${BAD_CHECKSUMS_FILE}"
+  fi
 done
 
 # rename and move files to files
@@ -164,9 +176,7 @@ rsync --ignore-existing -vrh "${PATH_TARGET}"/* "${PATH_ADDON_REPO}" | grep .zip
 # create addon.xml
 create_addon_xml
 
-# post to slack
-if [ -s "${PATH_LOG}" ]; then
-  slack "$(rsync_log)"
-fi
+# emit JSON result for GHA
+emit_result
 
 exit 0


### PR DESCRIPTION
Replace per-message curl calls with a single JSON emit from the script. Bad checksums are batched into one danger attachment; updates are posted as a good attachment grouped by architecture. Warnings and updates are two separate Slack steps so each gets the right colour.

Keeps secrets within GHA