### PR TITLE
yml-uses,deploy-addons: migrate Slack payloads to pure Block Kit

### DIFF
--- a/.github/workflows/deploy-addons.yml
+++ b/.github/workflows/deploy-addons.yml
@@ -110,9 +110,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.fmt.outputs.warnings_text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":warning: Warnings"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.fmt.outputs.warnings_text }}"
 
       - name: Notify updates
         if: steps.fmt.outputs.has_updates == 'true'
@@ -124,6 +131,13 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: good
-                text: "${{ steps.fmt.outputs.updates_text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":large_green_circle: Updated Add-ons"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.fmt.outputs.updates_text }}"

--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -271,9 +271,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -271,9 +271,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -269,9 +269,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -271,9 +271,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -269,9 +269,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -278,9 +278,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -278,9 +278,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -279,9 +279,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -280,9 +280,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -279,9 +279,16 @@ jobs:
             username: "ADDON Bot"
             icon_emoji: ":ghost:"
             channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
-            attachments:
-              - color: danger
-                text: "${{ steps.failures.outputs.text }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Build failures"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.failures.outputs.text }}"
 
       - name: Clean up - remove docker image tag
         if: always()


### PR DESCRIPTION
Replace the legacy `attachments` API with top-level Block Kit `blocks` across all 11 Slack notification steps (5 create-addon, 5 make-image, and deploy-addons warnings + updates).

Old payload (legacy — `attachments` is deprecated):
  attachments:
    - color: danger blocks: - type: section text: {type: mrkdwn, text: "..."}

New payload (pure Block Kit — no attachments at all):
  blocks:
    - type: header text: {type: plain_text, text: ":red_circle: Build failures", emoji: true}
    - type: section text: {type: mrkdwn, text: "..."}

  Failure notifications  — :red_circle: Build failures
  Addon warnings         — :warning: Warnings
  Addon updates          — :large_green_circle: Updated Add-ons

Slack has been deprecating the `attachments` API since 2018. The action we use (`slackapi/slack-github-action@v3`) fully supports top-level `blocks` via the incoming-webhook type. Using `blocks` inside `attachments` is still "legacy" because the wrapper itself is the deprecated element.

References:
- https://api.slack.com/messaging/composing/layouts#attachments
  "We recommend moving to Block Kit instead."
- https://api.slack.com/reference/block-kit/blocks#header
  header block — bold title bar, supports emoji: true
- https://api.slack.com/reference/block-kit/blocks#section
  section block — mrkdwn body text
- https://api.slack.com/tools/block-kit-builder
  Block Kit Builder — interactive payload sandbox
- https://github.com/slackapi/slack-github-action#technique-2-slack-incoming-webhook
  slackapi/slack-github-action@v3 incoming-webhook technique