### PR TITLE
yml-uses: Slack notification body improvements

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -237,7 +237,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          text="*${title}* (${LE_ADDON_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -246,9 +246,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              logtail=$(tail -50 "${logfile}")
+              if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
+                reason="BUILD"
+              else
+                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              fi
               if [ -z "${reason}" ]; then
-                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+                reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -237,7 +237,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          text="*${title}* (${LE_ADDON_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -246,9 +246,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              logtail=$(tail -50 "${logfile}")
+              if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
+                reason="BUILD"
+              else
+                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              fi
               if [ -z "${reason}" ]; then
-                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+                reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -244,9 +244,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              logtail=$(tail -50 "${logfile}")
+              if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
+                reason="BUILD"
+              else
+                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              fi
               if [ -z "${reason}" ]; then
-                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+                reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -235,7 +235,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          text="*${title}* (${LE_ADDON_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -237,7 +237,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          text="*${title}* (${LE_ADDON_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -246,9 +246,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              logtail=$(tail -50 "${logfile}")
+              if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
+                reason="BUILD"
+              else
+                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              fi
               if [ -z "${reason}" ]; then
-                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+                reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -244,9 +244,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(tail -200 "${logfile}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              logtail=$(tail -50 "${logfile}")
+              if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
+                reason="BUILD"
+              else
+                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+              fi
               if [ -z "${reason}" ]; then
-                reason=$(tail -200 "${logfile}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
+                reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -235,7 +235,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_ADDON_VERSION}):*\n"
+          text="*${title}* (${LE_ADDON_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -247,7 +247,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          text="*${title}* (${LE_DISTRO_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -247,7 +247,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          text="*${title}* (${LE_DISTRO_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -248,7 +248,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          text="*${title}* (${LE_DISTRO_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -249,7 +249,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          text="*${title}* (${LE_DISTRO_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -248,7 +248,7 @@ jobs:
           artifactdir="$(dirname "$(dirname "${joblog}")")/artifact"
           device="${{ env.DEVICE }}"
           title="${{ env.PROJECT }}${device:+.${device}}.${{ env.ARCH }}"
-          text="*Build failures - ${title} (${LE_DISTRO_VERSION}):*\n"
+          text="*${title}* (${LE_DISTRO_VERSION})\n"
           while IFS= read -r line; do
             step=$(awk '{ print $2 }' <<< "${line}")
             pkg=$(awk '{ print $5 }' <<< "${line}")


### PR DESCRIPTION
- Remove redundant "Build failures -" prefix from notification body — the
  Block Kit header block already carries that label

- Improve failure reason detection in create-addon workflows: reduce log
  scan window (tail -200 → tail -50) to prevent short-log false positives,
  and add BUILD detection for ninja FAILED: and "command not found" errors
  which now take priority over phase-keyword matching (UNPACK etc.)
