### PR TITLE
tools-cleanup-images: keep 3 months for the largest projects

### DIFF
--- a/.github/workflows/tools-cleanup-images.yml
+++ b/.github/workflows/tools-cleanup-images.yml
@@ -22,10 +22,19 @@ jobs:
           scp -P ${{ secrets.NIGHTLY_HOST_PORT }} actions/scripts/remote/release-scripts/prune-archive.py \
             ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:/tmp
 
+          # Baseline: keep 200 days of nightlies for all projects.
           # LE12.2
           ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
             "python3 /tmp/prune-archive.py -i /var/www/test/12.2/ -k 200 -d"
-
           # LE13
           ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
             "python3 /tmp/prune-archive.py -i /var/www/test/13.0/ -k 200 -d"
+
+          # Allwinner, Amlogic and Rockchip build many device images and use
+          # the most disk space: keep only 3 months (~90 days) for these.
+          # LE12.2
+          ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
+            "for p in Allwinner Amlogic Rockchip; do if [ -d /var/www/test/12.2/\$p ]; then python3 /tmp/prune-archive.py -i /var/www/test/12.2/\$p/ -k 90 -d; fi; done"
+          # LE13
+          ssh ${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }} -p ${{ secrets.NIGHTLY_HOST_PORT }} \
+            "for p in Allwinner Amlogic Rockchip; do if [ -d /var/www/test/13.0/\$p ]; then python3 /tmp/prune-archive.py -i /var/www/test/13.0/\$p/ -k 90 -d; fi; done"


### PR DESCRIPTION
prune-archive.py -k is a retention in days, not a file count. All
projects keep a 200-day baseline as before. Allwinner, Amlogic and
Rockchip build many device images and use the most disk space.

The 90-day pass loops over the three projects on the host with a
directory-existence guard, so a project absent on a branch is skipped
rather than failing the run. Applied to both 12.2 and 13.0.

Also bump the release-scripts submodule to ca49832, which removes the
companion .sha256 when an .img.gz is purged.