### PR TITLE
yml-uses: notify on job failure (upload/SCP errors)

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -305,3 +305,24 @@ jobs:
             ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }}:${{ secrets.ADDONS_UPLOAD_PATH }}/${{ env.LE_ADDON_VERSION }}
             printf "[\xE2\x9C\x94] %s\n" "${addonfiles##*/}"
           done
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -305,3 +305,24 @@ jobs:
             ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }}:${{ secrets.ADDONS_UPLOAD_PATH }}/${{ env.LE_ADDON_VERSION }}
             printf "[\xE2\x9C\x94] %s\n" "${addonfiles##*/}"
           done
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -305,3 +305,24 @@ jobs:
             ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }}:${{ secrets.ADDONS_UPLOAD_PATH }}/${{ env.LE_ADDON_VERSION }}
             printf "[\xE2\x9C\x94] %s\n" "${addonfiles##*/}"
           done
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -305,3 +305,24 @@ jobs:
             ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }}:${{ secrets.ADDONS_UPLOAD_PATH }}/${{ env.LE_ADDON_VERSION }}
             printf "[\xE2\x9C\x94] %s\n" "${addonfiles##*/}"
           done
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -305,3 +305,24 @@ jobs:
             ${{ secrets.ADDONS_HOST_USERNAME }}@${{ secrets.ADDONS_HOST }}:${{ secrets.ADDONS_UPLOAD_PATH }}/${{ env.LE_ADDON_VERSION }}
             printf "[\xE2\x9C\x94] %s\n" "${addonfiles##*/}"
           done
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -334,3 +334,24 @@ jobs:
                 "${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}/"
             done
           fi
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -334,3 +334,24 @@ jobs:
                 "${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}/"
             done
           fi
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -340,3 +340,24 @@ jobs:
                 "${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}/"
             done
           fi
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -336,3 +336,24 @@ jobs:
                 "${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}/"
             done
           fi
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -340,3 +340,24 @@ jobs:
                 "${{ secrets.NIGHTLY_HOST_USERNAME }}@${{ secrets.NIGHTLY_HOST }}:${{ secrets.NIGHTLY_UPLOAD_PATH }}/${{ env.LE_DISTRO_VERSION }}/${{ env.PROJECT }}/${uboot_device}/"
             done
           fi
+
+      - name: Notify job failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.ADDONS_REPO_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            username: "ADDON Bot"
+            icon_emoji: ":ghost:"
+            channel: "${{ secrets.ADDONS_REPO_WEBHOOK_CHANNEL }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":red_circle: Job failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ inputs.group }}*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"


### PR DESCRIPTION
Add if: failure() Slack notification to all 10 yml-uses-* files (5 make-image, 5 create-addon). Fires on any job failure not already caught by the existing build-failure notification step — specifically SCP upload failures that previously produced red builds silently.

The docker build step uses continue-on-error: true so build failures do not trigger this step; they remain handled by "Notify failed addon/image builds" with full per-package detail.