### PR TITLE
workflows: report failing package and patch in build-failure notifications

### DIFF
--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -250,7 +250,14 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                reason="${op}${subpkg:+ ${subpkg}}"
+                if [ "${op}" = "APPLY PATCH" ]; then
+                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  reason="${reason}${patch:+ (${patch})}"
+                fi
               fi
               if [ -z "${reason}" ]; then
                 reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")

--- a/.github/workflows/yml-uses-create-addon-LE10.yml
+++ b/.github/workflows/yml-uses-create-addon-LE10.yml
@@ -171,7 +171,7 @@ jobs:
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
                           -e ADDON_JENKINS=yes \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -250,12 +250,11 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
                 reason="${op}${subpkg:+ ${subpkg}}"
                 if [ "${op}" = "APPLY PATCH" ]; then
-                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                   reason="${reason}${patch:+ (${patch})}"
                 fi
               fi

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -250,7 +250,14 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                reason="${op}${subpkg:+ ${subpkg}}"
+                if [ "${op}" = "APPLY PATCH" ]; then
+                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  reason="${reason}${patch:+ (${patch})}"
+                fi
               fi
               if [ -z "${reason}" ]; then
                 reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")

--- a/.github/workflows/yml-uses-create-addon-LE11.yml
+++ b/.github/workflows/yml-uses-create-addon-LE11.yml
@@ -171,7 +171,7 @@ jobs:
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
                           -e ADDON_JENKINS=yes \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -250,12 +250,11 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
                 reason="${op}${subpkg:+ ${subpkg}}"
                 if [ "${op}" = "APPLY PATCH" ]; then
-                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                   reason="${reason}${patch:+ (${patch})}"
                 fi
               fi

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -248,7 +248,14 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                reason="${op}${subpkg:+ ${subpkg}}"
+                if [ "${op}" = "APPLY PATCH" ]; then
+                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  reason="${reason}${patch:+ (${patch})}"
+                fi
               fi
               if [ -z "${reason}" ]; then
                 reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")

--- a/.github/workflows/yml-uses-create-addon-LE12-2.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12-2.yml
@@ -169,7 +169,7 @@ jobs:
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
                           -e ADDON_JENKINS=yes \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -248,12 +248,11 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
                 reason="${op}${subpkg:+ ${subpkg}}"
                 if [ "${op}" = "APPLY PATCH" ]; then
-                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                   reason="${reason}${patch:+ (${patch})}"
                 fi
               fi

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -250,7 +250,14 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                reason="${op}${subpkg:+ ${subpkg}}"
+                if [ "${op}" = "APPLY PATCH" ]; then
+                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  reason="${reason}${patch:+ (${patch})}"
+                fi
               fi
               if [ -z "${reason}" ]; then
                 reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")

--- a/.github/workflows/yml-uses-create-addon-LE12.yml
+++ b/.github/workflows/yml-uses-create-addon-LE12.yml
@@ -171,7 +171,7 @@ jobs:
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
                           -e ADDON_JENKINS=yes \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -250,12 +250,11 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
                 reason="${op}${subpkg:+ ${subpkg}}"
                 if [ "${op}" = "APPLY PATCH" ]; then
-                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                   reason="${reason}${patch:+ (${patch})}"
                 fi
               fi

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -248,7 +248,14 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                reason=$(echo "${logtail}" | grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" | tail -1)
+                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                reason="${op}${subpkg:+ ${subpkg}}"
+                if [ "${op}" = "APPLY PATCH" ]; then
+                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  reason="${reason}${patch:+ (${patch})}"
+                fi
               fi
               if [ -z "${reason}" ]; then
                 reason=$(echo "${logtail}" | grep -oE "cannot stat '[^']+'" | tail -1 | sed "s|cannot stat '||;s|.*/||;s|'||")

--- a/.github/workflows/yml-uses-create-addon-LE13.yml
+++ b/.github/workflows/yml-uses-create-addon-LE13.yml
@@ -169,7 +169,7 @@ jobs:
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
                           -e ADDON_JENKINS=yes \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -248,12 +248,11 @@ jobs:
               if echo "${logtail}" | grep -qE "^FAILED:|command not found"; then
                 reason="BUILD"
               else
-                clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+                op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+                subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
                 reason="${op}${subpkg:+ ${subpkg}}"
                 if [ "${op}" = "APPLY PATCH" ]; then
-                  patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                  patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                   reason="${reason}${patch:+ (${patch})}"
                 fi
               fi

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -256,7 +256,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              reason="${op}${subpkg:+ ${subpkg}}"
+              if [ "${op}" = "APPLY PATCH" ]; then
+                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                reason="${reason}${patch:+ (${patch})}"
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-make-image-LE10.yml
+++ b/.github/workflows/yml-uses-make-image-LE10.yml
@@ -181,7 +181,7 @@ jobs:
                           -e PROJECT=${{ env.PROJECT }} \
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -256,12 +256,11 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
               reason="${op}${subpkg:+ ${subpkg}}"
               if [ "${op}" = "APPLY PATCH" ]; then
-                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                 reason="${reason}${patch:+ (${patch})}"
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -256,7 +256,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              reason="${op}${subpkg:+ ${subpkg}}"
+              if [ "${op}" = "APPLY PATCH" ]; then
+                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                reason="${reason}${patch:+ (${patch})}"
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-make-image-LE11.yml
+++ b/.github/workflows/yml-uses-make-image-LE11.yml
@@ -181,7 +181,7 @@ jobs:
                           -e PROJECT=${{ env.PROJECT }} \
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -256,12 +256,11 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
               reason="${op}${subpkg:+ ${subpkg}}"
               if [ "${op}" = "APPLY PATCH" ]; then
-                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                 reason="${reason}${patch:+ (${patch})}"
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -257,7 +257,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              reason="${op}${subpkg:+ ${subpkg}}"
+              if [ "${op}" = "APPLY PATCH" ]; then
+                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                reason="${reason}${patch:+ (${patch})}"
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-make-image-LE12-2.yml
+++ b/.github/workflows/yml-uses-make-image-LE12-2.yml
@@ -182,7 +182,7 @@ jobs:
                           -e PROJECT=${{ env.PROJECT }} \
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -257,12 +257,11 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
               reason="${op}${subpkg:+ ${subpkg}}"
               if [ "${op}" = "APPLY PATCH" ]; then
-                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                 reason="${reason}${patch:+ (${patch})}"
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -258,7 +258,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              reason="${op}${subpkg:+ ${subpkg}}"
+              if [ "${op}" = "APPLY PATCH" ]; then
+                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                reason="${reason}${patch:+ (${patch})}"
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-make-image-LE12.yml
+++ b/.github/workflows/yml-uses-make-image-LE12.yml
@@ -183,7 +183,7 @@ jobs:
                           -e PROJECT=${{ env.PROJECT }} \
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -258,12 +258,11 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
               reason="${op}${subpkg:+ ${subpkg}}"
               if [ "${op}" = "APPLY PATCH" ]; then
-                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                 reason="${reason}${patch:+ (${patch})}"
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -257,7 +257,14 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              reason=$(grep -ohE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              reason="${op}${subpkg:+ ${subpkg}}"
+              if [ "${op}" = "APPLY PATCH" ]; then
+                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                reason="${reason}${patch:+ (${patch})}"
+              fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"
             fi
           done <<< "${failed_lines}"

--- a/.github/workflows/yml-uses-make-image-LE13.yml
+++ b/.github/workflows/yml-uses-make-image-LE13.yml
@@ -182,7 +182,7 @@ jobs:
                           -e PROJECT=${{ env.PROJECT }} \
                           -e ARCH=${{ env.ARCH }} \
                           -e DEVICE=${{ env.DEVICE }} \
-                          -e ONELOG=no -e LOGCOMBINE=fail \
+                          -e ONELOG=no -e LOGCOMBINE=fail -e DISABLE_COLORS=yes \
                           -e BUILD_DIR=${{ env.build_dir }} \
                           -e BUILD_PERIODIC=${{ env.BUILD_PERIODIC }} \
                           -e CCACHE_DISABLE=${{ env.CCACHE_DISABLE }} \
@@ -257,12 +257,11 @@ jobs:
             logfile="${artifactdir}/${{ env.TARGETBUILDDIR }}-${pkgsafe}-$(basename "${logpath}")"
             text+="step [${step}/${total}] ${pkg}\n"
             if [ -f "${logfile}" ]; then
-              clean=$(sed -E 's/\x1b\[[0-9;]*m//g' "${logfile}")
-              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" <<< "${clean}" | tail -1)
-              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" <<< "${clean}" | tail -1 | awk '{ print $2 }')
+              op=$(grep -oE "APPLY PATCH|CONFIGURE|CMAKE|UNPACK" "${logfile}" | tail -1)
+              subpkg=$(grep -oE "UNPACK[[:space:]]+[^[:space:]]+" "${logfile}" | tail -1 | awk '{ print $2 }')
               reason="${op}${subpkg:+ ${subpkg}}"
               if [ "${op}" = "APPLY PATCH" ]; then
-                patch=$(grep "APPLY PATCH" <<< "${clean}" | tail -1 | awk '{ print $NF }')
+                patch=$(grep "APPLY PATCH" "${logfile}" | tail -1 | awk '{ print $NF }')
                 reason="${reason}${patch:+ (${patch})}"
               fi
               [ -n "${reason}" ] && text+="reason for failure - ${reason}\n"


### PR DESCRIPTION
The failure-reason extraction used grep -ohE, which discarded everything except the matched keyword, so every notification collapsed to a bare "APPLY PATCH" (or CONFIGURE/CMAKE/UNPACK) with no indication of which package or patch actually failed. A kodi patch failing during the JsonSchemaBuilder:host step was reported only as "APPLY PATCH".

Strip the ANSI colour codes first, then derive the reason as the failing phase plus the package being unpacked (the last UNPACK marker), and for patch failures append the failing patch path. The kodi case now reads:

    reason for failure - APPLY PATCH kodi (projects/Amlogic/patches/kodi/0001-workaround-for-subs-on-lima.patch)